### PR TITLE
added rails asset helpers

### DIFF
--- a/app/helpers/ember_assets_helper.rb
+++ b/app/helpers/ember_assets_helper.rb
@@ -1,0 +1,22 @@
+module EmberAssetsHelper
+  def ember_cli_rails_assets(app_name)
+    assets = {}
+
+    rails_asset_extensions = EmberCLI.get_app(app_name).rails_asset_extensions
+
+    Rails.application.config.assets.paths.each do |assets_path|
+      rails_asset_extensions.each do |file_ext|
+        Dir[File.join(assets_path, "**", "*#{file_ext}")].each do |absolute_path|
+          file = absolute_path.sub(File.join(assets_path, '/'), '')
+          assets[file] = asset_url(file)
+        end
+      end
+    end
+
+    assets
+  end
+
+  def include_ember_cli_rails_assets(app_name)
+    content_tag "script", "window.EMBER_CLI_RAILS_ASSETS = #{raw(ember_cli_rails_assets(app_name).to_json)}".html_safe
+  end
+end

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -4,6 +4,7 @@ module EmberCLI
   class App
     ADDON_VERSION = "0.0.11"
     EMBER_CLI_VERSION = "~> 0.1.5", "~> 0.2.0"
+    RAILS_ASSET_EXTENSIONS = %w(.jpg .png .jpeg .gif)
 
     class BuildError < StandardError; end
 
@@ -93,6 +94,10 @@ module EmberCLI
       end
     end
 
+    def rails_asset_extensions
+      options.fetch(:rails_asset_extensions, RAILS_ASSET_EXTENSIONS)
+    end
+
     private
 
     delegate :match_version?, :non_production?, to: Helpers
@@ -128,6 +133,10 @@ module EmberCLI
 
     def build_timeout
       options.fetch(:build_timeout){ configuration.build_timeout }
+    end
+
+    def asset_extensions
+      options.fetch(:asset_extensions) { configure.asset_extensions }
     end
 
     def lockfile


### PR DESCRIPTION
This pull request address #30. Once bundled into the rails app, add the following into your html:

```html
  <%= include_ember_cli_rails_assets :frontend %>
  ..

  <%= include_ember_script_tags :frontend %>
```

Once served, you should be able to access the following through the browser console:

```javascript
window.EMBER_CLI_RAILS_ASSETS
```

Note that this currently include all files with the following extensions:

```ruby
%w(.jpg .png .jpeg .gif)
```

If you want to customize this behavior (i.e. include font files, videos), you can do the following in your ember.rb initializer:

```ruby
EmberCLI.configure do |c|
  c.app :frontend, rails_asset_extensions: %w(.jpg .png .jpeg .gif .mpeg)
end
```

Please let me know if this works.