### PR TITLE
Support alternative (eg 'print') stylesheets

### DIFF
--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -6,4 +6,14 @@ module EmberRailsHelper
   def include_ember_stylesheet_tags(name, options={})
     stylesheet_link_tag *EmberCLI[name].exposed_css_assets, options
   end
+
+  def include_ember_alternative_stylesheet_tags(app_name, *sources)
+    app = EmberCLI[name]
+
+    sources = sources.map do |source_or_option|
+      (source_or_option.is_a? Hash) ? source_or_option : "#{app.name}/#{source_or_option}"
+    end
+
+    stylesheet_link_tag *sources
+  end
 end


### PR DESCRIPTION
In our app we need to be able to reference alternative CSS files that we will produce in Ember CLI. Specifically a print-media file. This is just one way of solving that (the simplest way that occurred to me). I just added another helper to which you can pass a list of stylesheets and options (just like the normal Rails helper). Here's how we're using my fork for testing now:

```html
    <%= include_ember_alternative_stylesheet_tags( :frontend, :print, media: 'print' ) %>
```

 I could see this being merged w/ the existing CSS helper method or maybe making that method somehow read the Ember CLI setup somehow (would still need to pass the media information somehwere). I'm happy to iterate on it or change the strategy.