### PR TITLE
Added the option to enable Ember CLI fingerprinting w/ bypass of asset pipeline

### DIFF
--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "railties", ">= 3.1", "< 5"
   spec.add_dependency "sprockets", ">= 2.0"
+  spec.add_dependency "json", "~> 1.7"
 end


### PR DESCRIPTION
Suggestion for how we can support Ember CLI fingerprints which seems necessary for referencing assets (eg images) from CSS within an Ember app. The idea here is that the optional parameter on the app definition in `config/initializers/ember.rb` causes Ember to generate fingerprinted assets. We have to copy the assets directly into `/public/assets/[APP_NAME]` so rather than linking the asset_path so that Rails does not re-fingerprint them.

In addition we fix up the Ember App's generated `manifest.json` file to prepend the app's name (e.g. `frontend/`) to the asset & file paths and merge the manifest with the manifest file in the root of `/public/assets` if it exists (in case of multiple apps). This allows the JS & CSS include helpers to work properly. This does require that `generateRailsManifest` be set to `true` in the Ember App's `Brocfile`. Perhaps we can do that automatically through the addon.

This works for multiple apps including having some apps using Ember CLI fingerprints and some using Rails fingerprinting. It does _not_ allow you to reference images within the Ember app from Rails CSS files (Rails doesn't look at the manifest file when doing asset precompilation so things work in dev but not in production). You might be able to reference images from Rails helpers in views, etc since those are dynamic and rely on the manifest file I believe.  I'm not sure that it makes sense to reach into the Ember app from Rails in any regard though I'm sure someone might find a reason to want to do so.