### PR TITLE
fixes #114 - add windows abstraction to handle file linking

### DIFF
--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -4,6 +4,7 @@ module EmberCLI
   extend self
 
   autoload :App,           "ember-cli/app"
+  autoload :AppWin,        "ember-cli/app_win"
   autoload :Configuration, "ember-cli/configuration"
   autoload :Helpers,       "ember-cli/helpers"
   autoload :Middleware,    "ember-cli/middleware"

--- a/lib/ember-cli/app_win.rb
+++ b/lib/ember-cli/app_win.rb
@@ -1,0 +1,31 @@
+module EmberCLI
+  class AppWin < EmberCLI::App
+
+    def ember_path
+      @ember_path ||= app_path.join("node_modules", ".bin", "ember").tap do |path|
+        fail <<-MSG.strip_heredoc unless path.exist?
+          No local ember executable found. You should run `npm install`
+          inside the #{name} app located at #{app_path}
+        MSG
+      end
+    end
+
+    def symlink_to_assets_root
+      exec ("cmd.exe /c \"mklink /J #{assets_path.join(name).to_s.gsub('/', '\\')} #{dist_path.join("assets").to_s.gsub('/', '\\')}\"")
+    rescue Errno::EEXIST
+      # Sometimes happens when starting multiple Unicorn workers.
+      # Ignoring...
+    end
+
+    def command(options={})
+      watch = options[:watch] ? "--watch" : ""
+
+      "\"#{ember_path}.cmd\" build #{watch} --environment #{environment} --output-path \"#{dist_path}\" #{log_pipe}"
+    end
+
+    def log_pipe
+      "| \"#{tee_path}\" -a \"#{log_path}\"" if tee_path
+    end
+
+  end
+end

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -5,7 +5,11 @@ module EmberCLI
     include Singleton
 
     def app(name, options={})
-      apps.store name, App.new(name, options)
+      if RUBY_PLATFORM =~ /mswin32|cygwin|mingw|bccwin/
+        apps.store name, AppWin.new(name, options)
+      else
+        apps.store name, App.new(name, options)
+      end
     end
 
     def apps


### PR DESCRIPTION
I have added a layer on top of the existing `EmberCLI::App` class that handles the linking when running on windows.

While the solution isn't pretty (and is a bit of a hack) I have found this to work reliably on windows.
