### PR TITLE
Add disable_fingerprints option

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -229,9 +229,13 @@ module EmberCLI
       Array.wrap(options[:exclude_ember_deps]).join(?,)
     end
 
+    def disable_fingerprints?
+      EmberCLI.configuration.disable_fingerprints
+    end
+
     def env_hash
       ENV.clone.tap do |vars|
-        vars.store "DISABLE_FINGERPRINTING", "true"
+        vars.store "DISABLE_FINGERPRINTING", disable_fingerprints?.to_s
         vars.store "EXCLUDE_EMBER_ASSETS", excluded_ember_deps
         vars.store "BUNDLE_GEMFILE", gemfile_path.to_s if gemfile_path.exist?
       end

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -29,6 +29,11 @@ module EmberCLI
       @build_timeout ||= 5
     end
 
-    attr_writer :build_timeout
+    def disable_fingerprints
+      return @disable_fingerprints if defined? @disable_fingerprints
+      @disable_fingerprints = true
+    end
+
+    attr_writer :build_timeout, :disable_fingerprints
   end
 end


### PR DESCRIPTION
Hello! This PR adds an option to EmberCLI.configure to disable the disabling of Ember asset fingerprinting. This is helpful for me when solving the problem of image fingerprinting as discussed in issue https://github.com/rwz/ember-cli-rails/issues/30.

In case it's useful, here's how I go about making sure the image asset fingerprints line up on disk and in source:
1. Add `extensions: ['png']` to the fingerprint hash in my Brocfile.js
2. Add `c.disable_fingerprints = Rails.env.development? || Rails.env.test?` to config/initializers/ember.rb
3. `RAILS_ENV=production rake assets:precompile` => rsync the assets directory to the server.
4. `cd frontend && ember build --environment=production` => rsync the assets/images directory to the server

It looks like there's another PR about having an asset fingerprinting option (https://github.com/rwz/ember-cli-rails/pull/132), but I'm not sure if it's trying to solve the same problem.

Let me know if you have any thoughts. Thank you!