### PR TITLE
Support passing in --watcher to pass to ember-cli

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -197,7 +197,8 @@ module EmberCLI
 
     def command(options={})
       watch = options[:watch] ? "--watch" : ""
-      "#{ember_path} build #{watch} --environment #{environment} --output-path #{dist_path} #{log_pipe}"
+      watcher = options[:watcher] ? "--watcher " +  options[:watcher] : ""
+      "#{ember_path} build #{watch} #{watcher} --environment #{environment} --output-path #{dist_path} #{log_pipe}"      
     end
 
     def log_pipe


### PR DESCRIPTION
Update app.rb to support passing in --watcher THEPOLLER

For example for those of us developing in Vagrant setting this to polling as detailed here http://www.ember-cli.com/#watched-files will really help the app to see the file changes made