### PR TITLE
Fixes #156 - Issue with spaces in paths

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -26,8 +26,8 @@ module EmberCLI
     end
 
     def install_dependencies
-      exec "#{bundler_path} install" if gemfile_path.exist?
-      exec "#{npm_path} install"
+      exec ["#{bundler_path}", "install"] if gemfile_path.exist?
+      exec ["#{npm_path}", "install"]
     end
 
     def run
@@ -41,7 +41,7 @@ module EmberCLI
 
     def run_tests
       prepare
-      exit 1 unless exec("#{ember_path} test")
+      exit 1 unless exec(["#{ember_path}", "test"])
     end
 
     def stop
@@ -197,11 +197,11 @@ module EmberCLI
 
     def command(options={})
       watch = options[:watch] ? "--watch" : ""
-      "#{ember_path} build #{watch} --environment #{environment} --output-path #{dist_path} #{log_pipe}"
-    end
 
-    def log_pipe
-      "| #{tee_path} -a #{log_path}" if tee_path
+      command_args = ["#{ember_path}", "build", "#{watch}", "--environment", "#{environment}", "--output-path", "#{dist_path}"]
+
+      # command_args = command_args + ["|", "#{tee_path}", "-a", "#{log_path}"] if tee_path
+      command_args
     end
 
     def ember_app_name
@@ -241,7 +241,7 @@ module EmberCLI
       method_name = options.fetch(:method, :system)
 
       Dir.chdir root do
-        Kernel.public_send(method_name, env_hash, cmd, err: :out)
+        Kernel.public_send(method_name, env_hash, *cmd, err: :out)
       end
     end
 


### PR DESCRIPTION
I've changed up the way that EmberCLI::App#exec works so that it takes it's 'command' param as an array and then uses the splat operator to deconstruct it.
This offloads the work of escaping the various different paths for spaces (which is surprisingly a pain in the ass) onto the system/spawn calls.

**Warning**: This breaks logging out to the log path alongside stdout using the 'tee' command. I don't think this should be merged until that is fixed. This issue is introduced because the pipe operator doesn't seem to be accepted by the system call when using the deconstructed arguments. I don't know why that is, and if anybody has any idea please let me know.

I'd obviously like to fix this, but I don't have the time right now and my project doesn't need the extra log file. My thoughts on fixing this is the pid handling code would need to be reworked a bit to handle a separate way of spawning off the build process such as using `IO.popen`. I'll hopefully get around to this as I don't want to get stuck on a particular version of this gem. :sweat_smile: 