### PR TITLE
Allow customizing precompile paths

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -193,7 +193,7 @@ module EmberCLI
     end
 
     def add_assets_to_precompile_list
-      Rails.configuration.assets.precompile << /\A#{name}\//
+      Rails.configuration.assets.precompile << options.fetch(:precompile, /\A#{name}\//)
     end
 
     def command(options={})


### PR DESCRIPTION
This allow overriding the default precompile paths for an app.

For example, if I only wanted to precompile JS files (and I do), I could do this:

```ruby
c.app :frontend, precompile: /\Afrontend\/(.*?).js$/
```

Because it's passed to Rails, you can also use a proc:

```ruby
c.app :frontend, precompile: -> { |path| path =~ /\Afrontend\// && File.extname(path).in?(['.css', '.js']) }
```