### PR TITLE
Fixes asset:precompile for Rails 3.1+ apps

### DIFF
--- a/lib/tasks/ember-cli.rake
+++ b/lib/tasks/ember-cli.rake
@@ -15,4 +15,11 @@ namespace :ember do
   end
 end
 
-task "assets:precompile" => "ember:compile" unless EmberCLI.skip?
+unless EmberCLI.skip?
+  # Hook into assets:precompile:all for Rails 3.1+
+  if Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new("4.0.0")
+    task "assets:precompile:all" => "ember:compile"
+  else
+    task "assets:precompile" => "ember:compile"
+  end
+end


### PR DESCRIPTION
Running `rake assets:precompile` in Rails versions prior to Rails 4 [kicks off a separate rake task](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/sprockets/assets.rake#L29) (`rake assets:precompile:all`) which spins up a new environment causing the original `ember:compile` task to be wasted. Rails 3.1+ needs to hook into `rake assets:precompile:all` so it fires the `ember build` command in the **real** precompile step. 