### PR TITLE
Better error messaging when Ember app is not installed.

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -146,6 +146,7 @@ module EmberCLI
 
     def prepare
       @prepared ||= begin
+        check_dependencies!
         check_addon!
         check_ember_cli_version!
         reset_build_error!
@@ -180,6 +181,19 @@ module EmberCLI
             $ npm install --save-dev ember-cli-rails-addon@#{ADDON_VERSION}
 
           in you Ember application root: #{root}
+        MSG
+      end
+    end
+
+    def check_dependencies!
+      unless node_modules_present?
+        fail <<-MSG.strip_heredoc
+          EmberCLI app dependencies are not installed. From your Rails application root please run:
+
+            $ bundle exec rake ember:install
+
+          If you do not require Ember at this URL, you can restrict this check using the `enable`
+          option in the EmberCLI initializer.
         MSG
       end
     end
@@ -223,6 +237,10 @@ module EmberCLI
     def addon_present?
       dev_dependencies["ember-cli-rails-addon"] == ADDON_VERSION &&
         addon_package_json_file_path.exist?
+    end
+
+    def node_modules_present?
+      node_modules_path.exist?
     end
 
     def excluded_ember_deps

--- a/lib/ember-cli/path_set.rb
+++ b/lib/ember-cli/path_set.rb
@@ -49,6 +49,10 @@ module EmberCLI
       root.join("package.json")
     end
 
+    define_path :node_modules do
+      root.join("node_modules")
+    end
+
     define_path :ember do
       root.join("node_modules", ".bin", "ember").tap do |path|
         fail <<-MSG.strip_heredoc unless path.executable?


### PR DESCRIPTION
Currently, if the user tries to go to a URL in the Rails app and the Ember app has not been installed, they see an error in their browser: `EmberCLI Rails requires your Ember app to have an addon.`, even when the problem is actually that they haven't installed the app yet.

This PR adds a check before `check_addons` called `check_dependencies` that checks that the `node_modules` directory exists. If it doesn't, then the user sees a more-relevant error message:

```
EmberCLI app dependencies are not installed. From your Rails application root please run:

     $ bundle exec rake ember:install

 If you do not require Ember at this URL, you can restrict this check using the `enable`
 option in the EmberCLI initializer.
```