### PR TITLE
Allow `enable` proc to accept Rack::Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Modify the `enable` configuration lambda to optionally accepts each requests'
+  `Rack::Request`. [#217]
 * Disable JS minification when generating Heroku setup [#238]
 * `BuildError#message` includes first line of backtrace. [#256]
 * Exposes `build_timeout` configuration as `ENV["EMBER_BUILD_TIMEOUT"]`.
@@ -10,6 +12,7 @@ master
 * `manifest.json`. Since we now defer to EmberCLI, we no longer need to
   manually resolve asset URLs. [#250]
 
+[#217]: https://github.com/thoughtbot/ember-cli-rails/pull/217
 [#238]: https://github.com/thoughtbot/ember-cli-rails/pull/238
 [#256]: https://github.com/thoughtbot/ember-cli-rails/pull/256
 [#250]: https://github.com/thoughtbot/ember-cli-rails/pull/250

--- a/README.md
+++ b/README.md
@@ -55,15 +55,15 @@ end
 - `path` - the path where your Ember CLI application is located. The default
   value is the name of your app in the Rails root.
 
-- `enable` - a lambda that accepts each request's path. The default value is a
-  lambda that returns `true`.
+- `enable` - a lambda that accepts each requests' path, and optionally the Rack
+  `request` itself. The default value is a lambda that returns `true`.
 
 ```ruby
 EmberCLI.configure do |c|
   c.app :adminpanel # path is "<your-rails-root>/adminpanel"
   c.app :frontend,
     path: "/path/to/your/ember-cli-app/on/disk",
-    enable: -> path { path.starts_with?("/app/") }
+    enable: -> path, request { path.starts_with?("/app/") }
 end
 ```
 

--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -60,8 +60,8 @@ module EmberCli
     each_app &:compile
   end
 
-  def process_path(path)
-    each_app{ |app| Runner.new(app, path).process }
+  def process_request(request)
+    each_app { |app| Runner.new(app, request).process }
   end
 
   def root

--- a/lib/ember-cli/build_constraint.rb
+++ b/lib/ember-cli/build_constraint.rb
@@ -1,0 +1,26 @@
+module EmberCli
+  class BuildConstraint
+    TRUE_PROC = ->(*) { true }
+
+    def initialize(request:, block:)
+      @request = request
+      @block = block || TRUE_PROC
+    end
+
+    def enabled?
+      block.call(*arguments)
+    end
+
+    private
+
+    attr_reader :request, :block
+
+    def arguments
+      [path, request].first([block.arity, 0].max)
+    end
+
+    def path
+      request.path_info
+    end
+  end
+end

--- a/lib/ember-cli/middleware.rb
+++ b/lib/ember-cli/middleware.rb
@@ -5,12 +5,12 @@ module EmberCli
     end
 
     def call(env)
-      path = env["PATH_INFO"].to_s
+      request = Rack::Request.new(env)
 
-      if path == "/testem.js"
+      if request.path_info == "/testem.js"
         [ 200, { "Content-Type" => "text/javascript" }, [""] ]
       else
-        EmberCli.process_path path
+        EmberCLI.process_request(request)
         @app.call(env)
       end
     end

--- a/lib/ember-cli/runner.rb
+++ b/lib/ember-cli/runner.rb
@@ -1,15 +1,16 @@
+require "ember-cli/build_constraint"
+
 module EmberCli
   class Runner
-    TRUE_PROC = ->(*){ true }
+    attr_reader :app, :request
 
-    attr_reader :app, :path
-
-    def initialize(app, path)
-      @app, @path = app, path
+    def initialize(app, request)
+      @app = app
+      @request = request
     end
 
     def process
-      return if skip?
+      return unless build.enabled?
 
       if EmberCli.env.development?
         start_or_restart!
@@ -22,9 +23,11 @@ module EmberCli
 
     private
 
-    def skip?
-      invoker = app.options.fetch(:enable, TRUE_PROC)
-      !invoker.call(path)
+    def build
+      BuildConstraint.new(
+        request: request,
+        block: app.options[:enabled],
+      )
     end
 
     def start_or_restart!

--- a/spec/ember-cli/build_constraint_spec.rb
+++ b/spec/ember-cli/build_constraint_spec.rb
@@ -1,0 +1,72 @@
+require "ember-cli/build_constraint"
+
+describe EmberCli::BuildConstraint do
+  describe "#enabled?" do
+    context "when #block is nil" do
+      it "returns true" do
+        constraint = EmberCli::BuildConstraint.new(
+          block: nil,
+          request: build_request,
+        )
+
+        expect(constraint.enabled?).to be true
+      end
+    end
+
+    context "when passed no arguments" do
+      it "captures the return value" do
+        invoked = false
+        constraint = EmberCli::BuildConstraint.new(
+          request: build_request,
+          block: lambda do
+            invoked = true
+          end,
+        )
+
+        expect(constraint.enabled?).to be true
+        expect(invoked).to be true
+      end
+    end
+
+    context "when passed a single argument" do
+      it "invokes the block with the path" do
+        path = nil
+        constraint = EmberCli::BuildConstraint.new(
+          request: build_request("path"),
+          block: lambda do |p|
+            path = p
+            :returned
+          end,
+        )
+
+        expect(constraint.enabled?).to be :returned
+        expect(path).to eq "path"
+      end
+    end
+
+    context "when passed two arguments" do
+      it "invokes the block with the path and Rack env" do
+        path = nil
+        request = nil
+        constraint = EmberCli::BuildConstraint.new(
+          request: build_request("new-path"),
+          block: lambda do |p, e|
+            path = p
+            request = e
+            :returned
+          end,
+        )
+
+        expect(constraint.enabled?).to be :returned
+        expect(path).to eq "new-path"
+        expect(request.env).to eq build_request("new-path").env
+      end
+    end
+
+    def build_request(path = "old-path")
+      Rack::Request.new(
+        "PATH_INFO" => path,
+      )
+    end
+  end
+end


### PR DESCRIPTION
Some requests can be routed differently, depending on the HTTP verb.

For instance, in FormKeep, we display the Ember app for `GET /f/:token`,
but handle a Form submission via a `POST /f/:token`.