### PR TITLE
Expose EmberCLI generated index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+master
+------
+
+* Introduce `include_ember_index_html` helper
+
 0.3.5
 -----
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,15 @@ end
 
 ##### options
 
-- app - this represents the name of the Ember CLI application.
+- `app` - this represents the name of the Ember CLI application.
 
-- path - the path where your Ember CLI application is located. The default
+- `build_timeout` - seconds to allow Ember to build the application before
+  timing out
+
+- `path` - the path where your Ember CLI application is located. The default
   value is the name of your app in the Rails root.
 
-- enable - a lambda that accepts each request's path. The default value is a
+- `enable` - a lambda that accepts each request's path. The default value is a
   lambda that returns `true`.
 
 ```ruby
@@ -73,7 +76,7 @@ ember init
 You will also need to install the [ember-cli-rails-addon](https://github.com/rondale-sc/ember-cli-rails-addon). For each of your Ember CLI applications, run:
 
 ```sh
-npm install --save-dev ember-cli-rails-addon@0.0.12
+npm install --save-dev ember-cli-rails-addon@0.0.13
 ```
 
 And that's it! You should now be able to start up your Rails server and see your Ember CLI app.
@@ -121,6 +124,23 @@ could render your app at the `/` route with the following view:
 ```
 
 Your Ember application will now be served at the `/` route.
+
+### Rendering the Ember index.html
+
+To render the EmberCLI generated `index.html` instead of using `javascript` and
+`stylesheet` tags, use `include_ember_index_html` (note, the asset paths will be
+replaced with asset pipeline generated paths):
+
+*NOTE* - Unlike using the asset tag helpers, this helper **requires** that the
+`index.html` file exists.
+
+To prevent race conditions, increase your `build_timeout` to ensure that the
+build finishes before your request is processed.
+
+```erb
+<!-- /app/views/application/index.html.erb -->
+<%= include_ember_index_html :frontend %>
+```
 
 ### Other routes
 

--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -1,4 +1,8 @@
 module EmberRailsHelper
+  def include_ember_index_html(name)
+    render inline: EmberCLI[name].index_html(self)
+  end
+
   def include_ember_script_tags(name, options={})
     javascript_include_tag *EmberCLI[name].exposed_js_assets, options
   end

--- a/lib/ember-cli/asset_resolver.rb
+++ b/lib/ember-cli/asset_resolver.rb
@@ -1,0 +1,54 @@
+module EmberCLI
+  class AssetResolver
+    def initialize(options)
+      @app = options.fetch(:app)
+      @sprockets = options.fetch(:sprockets)
+    end
+
+    def resolve_urls(html_content)
+      mappings.reduce(html_content) do |resolved_content, (asset, new_path)|
+        resolved_content.gsub(%{"assets/#{asset}"}, %{"#{new_path}"})
+      end
+    end
+
+    private
+
+    def mappings
+      {
+        "#{name}.js" => application.js,
+        "#{name}.css" => application.css,
+        "vendor.js" => vendor.js,
+        "vendor.css" => vendor.css,
+      }
+    end
+
+    def name
+      @app.name
+    end
+
+    def application
+      AssetPath.new(@sprockets, @app.application_assets)
+    end
+
+    def vendor
+      AssetPath.new(@sprockets, @app.vendor_assets)
+    end
+
+    class AssetPath
+      def initialize(sprockets, assets)
+        @sprockets = sprockets
+        @assets = assets
+      end
+
+      def js
+        @sprockets.asset_path(@assets, type: :javascript)
+      end
+
+      def css
+        @sprockets.asset_path(@assets, type: :stylesheet)
+      end
+    end
+
+    private_constant :AssetPath
+  end
+end

--- a/lib/ember-cli/html_page.rb
+++ b/lib/ember-cli/html_page.rb
@@ -1,0 +1,12 @@
+module EmberCLI
+  class HtmlPage
+    def initialize(options)
+      @content = options.fetch(:content)
+      @asset_resolver = options.fetch(:asset_resolver)
+    end
+
+    def render
+      @asset_resolver.resolve_urls(@content)
+    end
+  end
+end

--- a/lib/ember-cli/path_set.rb
+++ b/lib/ember-cli/path_set.rb
@@ -37,6 +37,10 @@ module EmberCLI
       EmberCLI.root.join("assets").tap(&:mkpath)
     end
 
+    define_path :applications do
+      Rails.root.join("public", "_apps").tap(&:mkpath)
+    end
+
     define_path :gemfile do
       root.join("Gemfile")
     end

--- a/spec/dummy/app/views/application/index.html.erb
+++ b/spec/dummy/app/views/application/index.html.erb
@@ -1,2 +1,6 @@
-<%= include_ember_script_tags "my-app" %>
-<%= include_ember_stylesheet_tags "my-app" %>
+<% if params[:index_html] %>
+  <%= include_ember_index_html "my-app" %>
+<% else %>
+  <%= include_ember_script_tags "my-app" %>
+  <%= include_ember_stylesheet_tags "my-app" %>
+<% end %>

--- a/spec/ember-cli/asset_resolver_spec.rb
+++ b/spec/ember-cli/asset_resolver_spec.rb
@@ -1,0 +1,65 @@
+require "ember-cli/asset_resolver"
+
+describe EmberCLI::AssetResolver do
+  describe "#resolve_urls" do
+    context "substitues asset pipeline paths" do
+      it "for application javascript" do
+        app = double(
+          name: "frontend",
+          application_assets: ["app", "asset"],
+          vendor_assets: ["vendor", "asset"],
+        )
+        sprockets = SprocketsMock.new
+        asset_resolver = EmberCLI::AssetResolver.new(
+          app: app,
+          sprockets: sprockets,
+        )
+        content = html_content
+
+        html = asset_resolver.resolve_urls(content).split("\n").map(&:strip)
+
+        expect(content).to eq html_content
+        expect(html).to eq [
+          %{<a href="unchanged/assets/frontend.js"></a>},
+          %{<a href="unchanged/assets/frontend.css"></a>},
+          %{<script src="app/asset.js"></script>},
+          %{<link href="app/asset.css"></script>},
+          %{<a href="unchanged/assets/vendor.js"></a>},
+          %{<a href="unchanged/assets/vendor.css"></a>},
+          %{<script src="vendor/asset.js"></script>},
+          %{<link href="vendor/asset.css"></script>},
+        ]
+      end
+    end
+  end
+
+  def html_content
+    <<-HTML
+      <a href="unchanged/assets/frontend.js"></a>
+      <a href="unchanged/assets/frontend.css"></a>
+      <script src="assets/frontend.js"></script>
+      <link href="assets/frontend.css"></script>
+      <a href="unchanged/assets/vendor.js"></a>
+      <a href="unchanged/assets/vendor.css"></a>
+      <script src="assets/vendor.js"></script>
+      <link href="assets/vendor.css"></script>
+    HTML
+  end
+
+  class SprocketsMock
+    def asset_path(routes, type: :javascript)
+      [routes.join("/"), extension_for(type)].join(".")
+    end
+    alias :vendor_path :asset_path
+
+    private
+
+    def extension_for(type)
+      if type == :javascript
+        "js"
+      else
+        "css"
+      end
+    end
+  end
+end

--- a/spec/ember-cli/html_page_spec.rb
+++ b/spec/ember-cli/html_page_spec.rb
@@ -1,0 +1,19 @@
+describe EmberCLI::HtmlPage do
+  describe "#render" do
+    it "resolves the Sprockets URLs in the content" do
+      asset_resolver = double("EmberCLI::AssetResolver")
+      html_page = EmberCLI::HtmlPage.new(
+        asset_resolver: asset_resolver,
+        content: :markup,
+      )
+      allow(asset_resolver).
+        to receive(:resolve_urls).
+        with(:markup).
+        and_return(:delegated)
+
+      rendered = html_page.render
+
+      expect(rendered).to be :delegated
+    end
+  end
+end

--- a/spec/features/user_views_ember_app_spec.rb
+++ b/spec/features/user_views_ember_app_spec.rb
@@ -1,6 +1,12 @@
 feature "User views ember app", :js do
-  scenario "from root" do
+  scenario "with asset helpers" do
     visit root_path
+
+    expect(page).to have_text "Welcome to Ember"
+  end
+
+  scenario "with index helper" do
+    visit root_path(index_html: true)
 
     expect(page).to have_text "Welcome to Ember"
   end


### PR DESCRIPTION
Depends on [rondale-sc/ember-cli-rails-addon#][#15].

Closes [#220].

Exposes new public methods for `EmberCLI::App`:

* `#index_html` - return the EmberCLI generated `index.html` string
* `#application_assets` - return the EmberCLI exposes app assets
* `#vendor_assets` - return the EmberCLI exposes vendor assets

Exposes new Rails helper:

* `include_ember_index_html` - Renders the `index.html` inline.
  Replaces EmberCLI asset paths with Sprockets asset paths

[#15]: rondale-sc/ember-cli-rails-addon#15
[#220]: #220