### PR TITLE
Drop Support for Ruby < 2.1.0 & Rails < 3.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ notifications:
   email: false
 
 rvm:
-- 2.2.0
-- 2.1.0
-- 2.0.0
+- 2.2
+- 2.1
 
 before_install:
   - qmake -version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Drop support for Ruby `< 2.1.0` and Rails `4.0.0, < 3.2.0`
 * Introduce `include_ember_index_html` helper
 
 0.3.5

--- a/README.md
+++ b/README.md
@@ -440,6 +440,17 @@ end
 
 jQuery and Handlebars are the main use cases for this flag.
 
+## Ruby and Rails support
+
+This project supports:
+
+* Ruby versions `>= 2.1.0`
+* Rails `3.2.x` and `>=4.1.x`.
+
+To learn more about supported versions and upgrades, read the [upgrading guide].
+
+[upgrading guide]: /UPGRADING.md
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,27 @@
+# Ruby support
+
+According to [these release notes][1.9.3-eol], Ruby versions prior to `2.0.x`
+has been end-of-lifed.
+
+Additionally, this codebase makes use of [(required) keyword arguments][kwargs].
+
+From `ember-cli-rails@0.4.0` and on, we will no longer support versions of Ruby
+prior to `2.1.0`.
+
+To use `ember-cli-rails` with older versions of Ruby, try the `0.3.x` series.
+
+[kwargs]: https://robots.thoughtbot.com/ruby-2-keyword-arguments
+[1.9.3-eol]: https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/
+
+# Rails support
+
+According to the [Rails Maintenance Policy][version-policy], Rails versions
+prior to `3.2.x` have been end-of-lifed. Additionally, the `4.0.x` series no
+longer receives bug fixes of any sort.
+
+From `ember-cli-rails@0.4.0` and on, we will no longer support versions of Rails
+prior to `3.2.0`, nor will we support the `4.0.x` series of releases.
+
+To use `ember-cli-rails` with older versions of Rails, try the `0.3.x` series.
+
+[version-policy]: http://guides.rubyonrails.org/maintenance_policy.html

--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -3,11 +3,11 @@ module EmberRailsHelper
     render inline: EmberCLI[name].index_html(self)
   end
 
-  def include_ember_script_tags(name, options={})
+  def include_ember_script_tags(name, **options)
     javascript_include_tag *EmberCLI[name].exposed_js_assets, options
   end
 
-  def include_ember_stylesheet_tags(name, options={})
+  def include_ember_stylesheet_tags(name, **options)
     stylesheet_link_tag *EmberCLI[name].exposed_css_assets, options
   end
 end

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.license  = "MIT"
   spec.files    = Dir["README.md", "CHANGELOG.md", "LICENSE.txt", "{lib,app,config}/**/*"]
 
-  spec.required_ruby_version = ">= 1.9.3"
+  spec.required_ruby_version = ">= 2.1.0"
 
-  spec.add_dependency "railties", ">= 3.1", "< 5"
+  spec.add_dependency "railties", ">= 3.2", "< 5"
   spec.add_dependency "sprockets", ">= 2.0"
 end

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -13,7 +13,7 @@ module EmberCLI
 
     delegate :root, to: :paths
 
-    def initialize(name, options={})
+    def initialize(name, **options)
       @name, @options = name.to_s, options
       @paths = PathSet.new(self)
     end
@@ -254,14 +254,18 @@ module EmberCLI
       Rails.configuration.assets.precompile << /\A#{name}\//
     end
 
-    def command(options={})
-      watch = ""
-      if options[:watch]
-        watch = "--watch"
-        watch += " --watcher #{watcher}" if watcher
+    def command(watch: false)
+      watch_flag = ""
+
+      if watch
+        watch_flag = "--watch"
+
+        if watcher
+          watch_flag += " --watcher #{watcher}"
+        end
       end
 
-      "#{ember_path} build #{watch} --environment #{environment} --output-path #{dist_path} #{log_pipe}"
+      "#{ember_path} build #{watch_flag} --environment #{environment} --output-path #{dist_path} #{log_pipe}"
     end
 
     def log_pipe
@@ -316,11 +320,9 @@ module EmberCLI
       end
     end
 
-    def exec(cmd, options={})
-      method_name = options.fetch(:method, :system)
-
+    def exec(cmd, method: :system)
       Dir.chdir root do
-        Kernel.public_send(method_name, env_hash, cmd, err: :out)
+        Kernel.public_send(method, env_hash, cmd, err: :out)
       end
     end
 

--- a/lib/ember-cli/asset_resolver.rb
+++ b/lib/ember-cli/asset_resolver.rb
@@ -1,8 +1,8 @@
 module EmberCLI
   class AssetResolver
-    def initialize(options)
-      @app = options.fetch(:app)
-      @sprockets = options.fetch(:sprockets)
+    def initialize(app:, sprockets:)
+      @app = app
+      @sprockets = sprockets
     end
 
     def resolve_urls(html_content)

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -4,7 +4,7 @@ module EmberCLI
   class Configuration
     include Singleton
 
-    def app(name, options={})
+    def app(name, **options)
       apps.store name, App.new(name, options)
     end
 

--- a/lib/ember-cli/html_page.rb
+++ b/lib/ember-cli/html_page.rb
@@ -1,8 +1,8 @@
 module EmberCLI
   class HtmlPage
-    def initialize(options)
-      @content = options.fetch(:content)
-      @asset_resolver = options.fetch(:asset_resolver)
+    def initialize(content:, asset_resolver:)
+      @content = content
+      @asset_resolver = asset_resolver
     end
 
     def render


### PR DESCRIPTION
Ruby support
------------

According to [these release notes][1.9.3-eol], Ruby versions prior to `2.0.x`
has been end-of-lifed.

Additionally, this codebase makes use of [(required) keyword arguments][kwargs].

From `ember-cli-rails@0.4.0` and on, we will no longer support versions of Ruby
prior to `2.1.0`.

To use `ember-cli-rails` with older versions of Ruby, try the `0.3.x` series.

[kwargs]: https://robots.thoughtbot.com/ruby-2-keyword-arguments
[1.9.3-eol]: https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/

Rails support
-------------

According to the [Rails Maintenance Policy][version-policy], Rails versions
prior to `3.2.x` have been end-of-lifed. Additionally, the `4.0.x` series no
longer receives bug fixes of any sort.

From `ember-cli-rails@0.4.0` and on, we will no longer support versions of Rails
prior to `3.2.0`, nor will we support the `4.0.x` series of releases.

To use `ember-cli-rails` with older versions of Rails, try the `0.3.x` series.

[version-policy]: http://guides.rubyonrails.org/maintenance_policy.html