### PR TITLE
Inject into EmberCLI generated index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ master
 ------
 
 * Extend `include_ember_index_html` helper to accept a block. The contents of
-  the block will be injected into the page's `<head>` tag.
+  the block will be injected into the page
 * Drop support for Ruby `< 2.1.0` and Rails `4.0.0, < 3.2.0`
 * Introduce `rails g ember-cli:heroku` generator to configure a project for
   deploying to Heroku

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Extend `include_ember_index_html` helper to accept a block. The contents of
+  the block will be injected into the page's `<head>` tag.
 * Drop support for Ruby `< 2.1.0` and Rails `4.0.0, < 3.2.0`
 * Introduce `rails g ember-cli:heroku` generator to configure a project for
   deploying to Heroku

--- a/README.md
+++ b/README.md
@@ -95,54 +95,11 @@ end
 
 ## Usage
 
-You render your Ember CLI app by including the corresponding JS/CSS tags in whichever
-Rails view you'd like the Ember app to appear.
-
-For example, if you had the following Rails app
-
-```rb
-# /config/routes.rb
-Rails.application.routes.draw do
-  root 'application#index'
-end
-
-# /app/controllers/application_controller.rb
-class ApplicationController < ActionController::Base
-  def index
-    render :index
-  end
-end
-```
-
-and if you had created an Ember app `:frontend` in your initializer, then you
-could render your app at the `/` route with the following view:
-
-```erb
-<!-- /app/views/application/index.html.erb -->
-<%= include_ember_script_tags :frontend %>
-<%= include_ember_stylesheet_tags :frontend %>
-```
-
-Your Ember application will now be served at the `/` route.
-
-### Rendering the Ember index.html
-
-To render the EmberCLI generated `index.html` instead of using `javascript` and
-`stylesheet` tags, use `include_ember_index_html` (note, the asset paths will be
-replaced with asset pipeline generated paths):
-
-*NOTE* - Unlike using the asset tag helpers, this helper **requires** that the
-`index.html` file exists.
-
-To prevent race conditions, increase your `build_timeout` to ensure that the
-build finishes before your request is processed.
-
 First, specify in your controller that you don't want to render the layout
 (since EmberCLI's `index.html` is a fully-formed HTML document):
 
 ```rb
 # app/controllers/application.rb
-
 class ApplicationController < ActionController::Base
   def index
     render layout: false
@@ -150,7 +107,9 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-Then, use the helper in your view:
+To render the EmberCLI generated `index.html` into the view,
+use the `include_ember_index_html` helper:
+
 
 ```erb
 <!-- /app/views/application/index.html.erb -->
@@ -167,6 +126,29 @@ To inject markup into page, pass in a block that accepts the `head`, and
     <%= csrf_meta_tags %>
   <% end %>
 <% end %>
+```
+
+The asset paths will be replaced with asset pipeline generated paths.
+
+*NOTE*
+
+This helper **requires** that the `index.html` file exists.
+
+If you see `Errno::ENOENT` errors in development, your requests are timing out
+before EmberCLI finishes compiling the application.
+
+To prevent race conditions, increase your `build_timeout` to ensure that the
+build finishes before your request is processed.
+
+### Rendering the EmberCLI generated JS and CSS
+
+In addition to rendering the EmberCLI generated `index.html`, you can inject the
+`<script>` and `<link>` tags into your Rails generated views:
+
+```erb
+<!-- /app/views/application/index.html.erb -->
+<%= include_ember_script_tags :frontend %>
+<%= include_ember_stylesheet_tags :frontend %>
 ```
 
 ### Other routes

--- a/README.md
+++ b/README.md
@@ -137,9 +137,36 @@ replaced with asset pipeline generated paths):
 To prevent race conditions, increase your `build_timeout` to ensure that the
 build finishes before your request is processed.
 
+First, specify in your controller that you don't want to render the layout
+(since EmberCLI's `index.html` is a fully-formed HTML document):
+
+```rb
+# app/controllers/application.rb
+
+class ApplicationController < ActionController::Base
+  def index
+    render layout: false
+  end
+end
+```
+
+Then, use the helper in your view:
+
 ```erb
 <!-- /app/views/application/index.html.erb -->
 <%= include_ember_index_html :frontend %>
+```
+
+To inject markup into page, pass in a block that accepts the `head`, and
+(optionally) the `body`:
+
+```erb
+<!-- /app/views/application/index.html.erb -->
+<%= include_ember_index_html :frontend do |head| %>
+  <%= head.append do %>
+    <%= csrf_meta_tags %>
+  <% end %>
+<% end %>
 ```
 
 ### Other routes

--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -1,13 +1,25 @@
+require "ember-cli/capture"
+
 module EmberRailsHelper
-  def include_ember_index_html(name)
-    render inline: EmberCLI[name].index_html(self)
+  def include_ember_index_html(name, &block)
+    markup_capturer = EmberCLI::Capture.new(sprockets: self, &block)
+
+    head, body = markup_capturer.capture
+
+    html = EmberCLI[name].index_html(
+      sprockets: self,
+      head: head,
+      body: body,
+    )
+
+    render inline: html
   end
 
   def include_ember_script_tags(name, **options)
-    javascript_include_tag *EmberCLI[name].exposed_js_assets, options
+    javascript_include_tag(*EmberCLI[name].exposed_js_assets, options)
   end
 
   def include_ember_stylesheet_tags(name, **options)
-    stylesheet_link_tag *EmberCLI[name].exposed_css_assets, options
+    stylesheet_link_tag(*EmberCLI[name].exposed_css_assets, options)
   end
 end

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -68,7 +68,7 @@ module EmberCLI
       @pid = nil
     end
 
-    def index_html(sprockets)
+    def index_html(sprockets:, head:, body:)
       asset_resolver = AssetResolver.new(
         app: self,
         sprockets: sprockets,
@@ -76,6 +76,8 @@ module EmberCLI
       html_page = HtmlPage.new(
         asset_resolver: asset_resolver,
         content: index_file.read,
+        head: head,
+        body: body,
       )
 
       html_page.render

--- a/lib/ember-cli/capture.rb
+++ b/lib/ember-cli/capture.rb
@@ -1,0 +1,54 @@
+module EmberCLI
+  class Capture
+    attr_reader :body, :head
+
+    def initialize(sprockets:, &block)
+      @sprockets = sprockets
+      @block = block
+    end
+
+    def capture
+      if @block.present?
+        if @block.arity == 0
+          @head = @sprockets.capture(&@block)
+          @body = ""
+        else
+          arguments = [captured_head, captured_body].first(@block.arity)
+          @block.call(*arguments)
+          @head = captured_head.content
+          @body = captured_body.content
+        end
+
+        [@head, @body]
+      else
+        ["", ""]
+      end
+    end
+
+    private
+
+    def captured_body
+      @captured_body ||= Block.new(@sprockets)
+    end
+
+    def captured_head
+      @captured_head ||= Block.new(@sprockets)
+    end
+
+    class Block
+      def initialize(sprockets)
+        @sprockets = sprockets
+        @content = []
+      end
+
+      def append(&block)
+        @content.push(@sprockets.capture(&block))
+      end
+
+      def content
+        @content.join
+      end
+    end
+    private_constant :Block
+  end
+end

--- a/lib/ember-cli/capture.rb
+++ b/lib/ember-cli/capture.rb
@@ -1,25 +1,17 @@
 module EmberCLI
   class Capture
-    attr_reader :body, :head
-
     def initialize(sprockets:, &block)
       @sprockets = sprockets
       @block = block
     end
 
     def capture
-      if @block.present?
-        if @block.arity == 0
-          @head = @sprockets.capture(&@block)
-          @body = ""
+      if block.present?
+        if block.arity == 0
+          capture_block
         else
-          arguments = [captured_head, captured_body].first(@block.arity)
-          @block.call(*arguments)
-          @head = captured_head.content
-          @body = captured_body.content
+          captured_head_and_body
         end
-
-        [@head, @body]
       else
         ["", ""]
       end
@@ -27,12 +19,26 @@ module EmberCLI
 
     private
 
+    attr_reader :block, :sprockets
+
+    def captured_head_and_body
+      arguments = [captured_head, captured_body].first(block.arity)
+
+      block.call(*arguments)
+
+      [captured_head.content, captured_body.content]
+    end
+
+    def capture_block
+      [sprockets.capture(&block), ""]
+    end
+
     def captured_body
-      @captured_body ||= Block.new(@sprockets)
+      @captured_body ||= Block.new(sprockets)
     end
 
     def captured_head
-      @captured_head ||= Block.new(@sprockets)
+      @captured_head ||= Block.new(sprockets)
     end
 
     class Block

--- a/lib/ember-cli/html_page.rb
+++ b/lib/ember-cli/html_page.rb
@@ -1,11 +1,55 @@
 module EmberCLI
   class HtmlPage
-    def initialize(content:, asset_resolver:)
+    def initialize(content:, asset_resolver:, head: "", body: "")
       @content = content
       @asset_resolver = asset_resolver
+      @head = head
+      @body = body
     end
 
     def render
+      if has_head_tag?
+        insert_head_content
+      end
+
+      if has_body_tag?
+        insert_body_content
+      end
+
+      html
+    end
+
+    private
+
+    def has_head_tag?
+      head_tag_index >= 0
+    end
+
+    def has_body_tag?
+      body_tag_index >= 0
+    end
+
+    def insert_head_content
+      html.insert(head_tag_index, @head.to_s)
+    end
+
+    def insert_body_content
+      html.insert(body_tag_index, @body.to_s)
+    end
+
+    def html
+      @html ||= resolved_html
+    end
+
+    def head_tag_index
+      html.index("</head") || -1
+    end
+
+    def body_tag_index
+      html.index("</body") || -1
+    end
+
+    def resolved_html
       @asset_resolver.resolve_urls(@content)
     end
   end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -2,4 +2,8 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  def index
+    render layout: params[:index_html].blank?
+  end
 end

--- a/spec/dummy/app/views/application/index.html.erb
+++ b/spec/dummy/app/views/application/index.html.erb
@@ -1,5 +1,22 @@
 <% if params[:index_html] %>
-  <%= include_ember_index_html "my-app" %>
+  <% if params[:empty_block] %>
+    <%= include_ember_index_html "my-app" do %>
+      <%= csrf_meta_tags %>
+    <% end %>
+  <% elsif params[:head_and_body] %>
+    <%= include_ember_index_html "my-app" do |head, body| %>
+      <%= head.append do %>
+        <%= csrf_meta_tags %>
+      <% end %>
+
+      <%= body.append do %>
+        <p>Hello from Rails</p>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= include_ember_index_html "my-app" %>
+  <% end %>
+
 <% else %>
   <%= include_ember_script_tags "my-app" %>
   <%= include_ember_stylesheet_tags "my-app" %>

--- a/spec/ember-cli/html_page_spec.rb
+++ b/spec/ember-cli/html_page_spec.rb
@@ -1,19 +1,67 @@
 describe EmberCLI::HtmlPage do
   describe "#render" do
-    it "resolves the Sprockets URLs in the content" do
-      asset_resolver = double("EmberCLI::AssetResolver")
-      html_page = EmberCLI::HtmlPage.new(
-        asset_resolver: asset_resolver,
-        content: :markup,
-      )
-      allow(asset_resolver).
+    context "when <head> is present" do
+      it "injects into the <head>" do
+        content = valid_content
+        html_page = EmberCLI::HtmlPage.new(
+          asset_resolver: build_asset_resolver(content),
+          content: content,
+          head: "injected!",
+        )
+
+        rendered = html_page.render
+
+        expect(rendered).to eq(
+          "<html><head><title></title>injected!</head><body><h1></h1></body></html>",
+        )
+      end
+    end
+
+    context "when <body> is present" do
+      it "injects into the <body>" do
+        content = valid_content
+        html_page = EmberCLI::HtmlPage.new(
+          asset_resolver: build_asset_resolver(content),
+          content: content,
+          body: "injected!",
+        )
+
+        rendered = html_page.render
+
+        expect(rendered).to eq(
+          "<html><head><title></title></head><body><h1></h1>injected!</body></html>",
+        )
+      end
+    end
+
+    context "when the page isn't valid" do
+      it "does nothing" do
+        content = "<html></html>"
+        html_page = EmberCLI::HtmlPage.new(
+          asset_resolver: build_asset_resolver(content),
+          content: content,
+          head: "injected!",
+          body: "injected!",
+        )
+
+        rendered = html_page.render
+
+        expect(rendered).to eq("<html></html>")
+      end
+    end
+
+    def build_asset_resolver(content)
+      resolver = double("EmberCLI::AssetResolver")
+      allow(resolver).
         to receive(:resolve_urls).
-        with(:markup).
-        and_return(:delegated)
+        with(content).
+        and_return(content)
 
-      rendered = html_page.render
+      resolver
+    end
 
-      expect(rendered).to be :delegated
+    def valid_content
+      "<html><head><title></title></head><body><h1></h1></body></html>"
     end
   end
 end

--- a/spec/features/user_views_ember_app_spec.rb
+++ b/spec/features/user_views_ember_app_spec.rb
@@ -3,11 +3,32 @@ feature "User views ember app", :js do
     visit root_path
 
     expect(page).to have_text "Welcome to Ember"
+    expect(page).to have_csrf_tags
   end
 
   scenario "with index helper" do
     visit root_path(index_html: true)
 
     expect(page).to have_text "Welcome to Ember"
+    expect(page).to have_no_csrf_tags
+
+    visit root_path(index_html: true, empty_block: true)
+
+    expect(page).to have_csrf_tags
+
+    visit root_path(index_html: true, head_and_body: true)
+
+    expect(page).to have_csrf_tags
+    expect(page).to have_text "Hello from Rails"
+  end
+
+  def have_no_csrf_tags
+    have_no_css("meta[name=csrf-param]", visible: false).
+      and have_no_css("meta[name=csrf-token]", visible: false)
+  end
+
+  def have_csrf_tags
+    have_css("meta[name=csrf-param]", visible: false).
+      and have_css("meta[name=csrf-token]", visible: false)
   end
 end


### PR DESCRIPTION
To inject markup into the `<head>`, pass in a block:

```erb
<%= include_ember_index_html :frontend do %>
  <%= csrf_meta_tags %>
<% end %>
```

This gives users the best of both worlds:

* defers to EmberCLI to build the page (integrating with `content-for`
  blocks) and addons that alter the `index.html`
* allows the Rails app to inject arbitrary markup into the `<head>`,
  such as CSRF tags, stylesheets, or anything else