### PR TITLE
Inject into EmberCLI generated index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,26 +301,13 @@ directories %w[app config lib spec your-appname/app]
 
 ## Heroku
 
-In order to deploy Ember CLI Rails app to Heroku:
+To configure your Ember CLI Rails app to be ready to deploy on Heroku:
 
-First, enable Heroku Multi Buildpack by running the following command:
+1. Run `rails g ember-cli:heroku` generator
+1. Enable Heroku Multi Buildpack by running the following command:
 
 ```sh
 heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi
-```
-
-Next, specify which buildpacks to use by creating a `.buildpacks` file in the project root containing:
-
-```
-https://github.com/heroku/heroku-buildpack-nodejs
-https://github.com/heroku/heroku-buildpack-ruby
-```
-
-Add `rails_12factor` gem to your production group in Gemfile, then run `bundle
-install`:
-
-```ruby
-gem "rails_12factor", group: :production
 ```
 
 Add a `package.json` file containing `{}` to the root of your Rails project.

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -30,7 +30,8 @@ module EmberCLI
 
     def install_dependencies
       exec "#{bundler_path} install" if gemfile_path.exist?
-      exec "#{npm_path} install"
+      exec "#{npm_path} prune && #{npm_path} install"
+      exec "#{bower_path} && #{bower_path} install"
     end
 
     def run

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -17,6 +17,12 @@ module EmberCLI
       @tee_path = Helpers.which("tee")
     end
 
+    def bower_path
+      @bower_path ||=
+        Helpers.which("bower") ||
+        Rails.root.join("node_modules", ".bin", "bower")
+    end
+
     def npm_path
       @npm_path ||= Helpers.which("npm")
     end

--- a/lib/generators/ember-cli/heroku/USAGE
+++ b/lib/generators/ember-cli/heroku/USAGE
@@ -1,0 +1,9 @@
+Description:
+  Generates files necessary to deploy the project to Heroku
+
+Example:
+    rails generate ember-cli:heroku
+
+    This will create:
+        .buildpacks
+        package.json

--- a/lib/generators/ember-cli/heroku/heroku_generator.rb
+++ b/lib/generators/ember-cli/heroku/heroku_generator.rb
@@ -1,0 +1,21 @@
+module EmberCLI
+  class HerokuGenerator < Rails::Generators::Base
+    source_root File.expand_path("../templates", __FILE__)
+
+    namespace "ember-cli:heroku"
+
+    gem "rails_12factor", group: [:staging, :production]
+
+    def copy_buildpack_file
+      copy_file "buildpacks", ".buildpacks"
+    end
+
+    def copy_package_json_file
+      template "package.json.erb", "package.json"
+    end
+
+    def apps
+      EmberCLI.apps.keys
+    end
+  end
+end

--- a/lib/generators/ember-cli/heroku/templates/buildpacks
+++ b/lib/generators/ember-cli/heroku/templates/buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs
+https://github.com/heroku/heroku-buildpack-ruby

--- a/lib/generators/ember-cli/heroku/templates/package.json.erb
+++ b/lib/generators/ember-cli/heroku/templates/package.json.erb
@@ -1,0 +1,15 @@
+{
+  "scripts": {
+    "postinstall": "bundle exec rake ember:install"
+  },
+  "devDependencies": {
+    "bower": "*"
+  },
+  "cacheDirectories": [
+    <% apps.each do |app| %>
+    "<%= app %>/node_modules",
+    "<%= app %>/bower_components",
+    <% end %>
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
To inject markup into the `<head>`, pass in a block:

```erb
<%= include_ember_index_html :frontend do %>
  <%= csrf_meta_tags %>
<% end %>
```

This gives users the best of both worlds:

* defers to EmberCLI to build the page (integrating with `content-for`
  blocks) and addons that alter the `index.html`
* allows the Rails app to inject arbitrary markup into the `<head>`,
  such as CSRF tags, stylesheets, or anything else