### PR TITLE
Add `rails g ember-cli:heroku`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ master
 ------
 
 * Drop support for Ruby `< 2.1.0` and Rails `4.0.0, < 3.2.0`
+* Introduce `rails g ember-cli:heroku` generator to configure a project for
+  deploying to Heroku
 * Introduce `include_ember_index_html` helper
 
 0.3.5

--- a/README.md
+++ b/README.md
@@ -301,50 +301,23 @@ directories %w[app config lib spec your-appname/app]
 
 ## Heroku
 
-In order to deploy Ember CLI Rails app to Heroku:
+To configure your Ember CLI Rails app to be ready to deploy on Heroku:
 
-First, enable Heroku Multi Buildpack by running the following command:
+1. Run `rails g ember-cli:heroku` generator
+1. [Add the NodeJS buildpack][buildpack] and configure NPM to include the
+   `bower` dependency's executable file.
 
 ```sh
-heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi
+heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-nodejs
+heroku config:set NPM_CONFIG_PRODUCTION=false
 ```
 
-Next, specify which buildpacks to use by creating a `.buildpacks` file in the project root containing:
+You should be ready to deploy.
 
-```
-https://github.com/heroku/heroku-buildpack-nodejs
-https://github.com/heroku/heroku-buildpack-ruby
-```
+**NOTE** Run the generator each time you introduce additional EmberCLI
+applications into the project.
 
-Add `rails_12factor` gem to your production group in Gemfile, then run `bundle
-install`:
-
-```ruby
-gem "rails_12factor", group: :production
-```
-
-Add a `package.json` file containing `{}` to the root of your Rails project.
-This is to make sure it'll be detected by the NodeJS buildpack.
-
-Make sure you have `bower` as a npm dependency of your ember-cli app.
-
-Add a `postinstall` task to your Ember CLI app's `package.json`. This will
-ensure that during the deployment process, Heroku will install all dependencies
-found in both `node_modules` and `bower_components`.
-
-```javascript
-{
-  # ...
-  "scripts": {
-    # ...
-    "postinstall": "node_modules/bower/bin/bower install"¬
-  }
-}
-```
-
-ember-cli-rails adds your ember apps' build process to the rails asset compilation process.
-
-Now you should be ready to deploy.
+[buildpack]: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#adding-a-buildpack
 
 ## Capistrano
 

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -29,8 +29,23 @@ module EmberCLI
     end
 
     def install_dependencies
-      exec "#{bundler_path} install" if gemfile_path.exist?
-      exec "#{npm_path} install"
+      if gemfile_path.exist?
+        exec "#{bundler_path} install"
+      end
+
+      exec "#{npm_path} prune && #{npm_path} install"
+
+      if bower_path.nil?
+        fail <<-FAIL
+          Bower is required by EmberCLI.
+
+          Install it with:
+
+              $ npm install -g bower
+        FAIL
+      else
+        exec "#{bower_path} prune && #{bower_path} install"
+      end
     end
 
     def run

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -17,6 +17,10 @@ module EmberCLI
       @tee_path = Helpers.which("tee")
     end
 
+    def bower_path
+      @bower_path ||= Helpers.which("bower")
+    end
+
     def npm_path
       @npm_path ||= Helpers.which("npm")
     end

--- a/lib/ember-cli/path_set.rb
+++ b/lib/ember-cli/path_set.rb
@@ -78,6 +78,10 @@ module EmberCLI
       app_options.fetch(:tee_path){ configuration.tee_path }
     end
 
+    define_path :bower do
+      app_options.fetch(:bower_path) { configuration.bower_path }
+    end
+
     define_path :npm do
       app_options.fetch(:npm_path){ configuration.npm_path }
     end

--- a/lib/generators/ember-cli/heroku/USAGE
+++ b/lib/generators/ember-cli/heroku/USAGE
@@ -1,0 +1,17 @@
+Description:
+    Configures a project for deploying to Heroku.
+
+    Once the generator is complete, execute the following:
+
+        heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-nodejs
+        heroku config:set NPM_CONFIG_PRODUCTION=false
+
+Example:
+    rails generate ember-cli:heroku
+
+    This will install the following gems:
+        rails_12factor
+
+    This will create:
+        bin/heroku_install
+        package.json

--- a/lib/generators/ember-cli/heroku/heroku_generator.rb
+++ b/lib/generators/ember-cli/heroku/heroku_generator.rb
@@ -1,0 +1,26 @@
+module EmberCLI
+  class HerokuGenerator < Rails::Generators::Base
+    source_root File.expand_path("../templates", __FILE__)
+
+    namespace "ember-cli:heroku"
+
+    def copy_package_json_file
+      template "package.json.erb", "package.json"
+    end
+
+    def copy_setup_heroku_file
+      template "bin_heroku_install.erb", "bin/heroku_install"
+      run "chmod a+x bin/heroku_install"
+    end
+
+    def inject_12factor_gem
+      gem "rails_12factor", group: [:staging, :production]
+    end
+
+    def app_paths
+      EmberCLI.apps.values.map do |app|
+        app.root.relative_path_from(Rails.root)
+      end
+    end
+  end
+end

--- a/lib/generators/ember-cli/heroku/templates/bin_heroku_install.erb
+++ b/lib/generators/ember-cli/heroku/templates/bin_heroku_install.erb
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -e
+
+bower="$(pwd)/node_modules/.bin/bower"
+
+for app in <%= app_paths.map { |app_path| %{"#{app_path}"} }.join(" ") -%>; do
+  cd $app &&
+    npm prune &&
+    npm install &&
+    $bower prune &&
+    $bower install
+done

--- a/lib/generators/ember-cli/heroku/templates/package.json.erb
+++ b/lib/generators/ember-cli/heroku/templates/package.json.erb
@@ -1,0 +1,15 @@
+{
+  "scripts": {
+    "postinstall": "./bin/heroku_install"
+  },
+  "devDependencies": {
+    "bower": "*"
+  },
+  "cacheDirectories": [
+    <%- app_paths.each do |app_path| -%>
+    "<%= app_path %>/node_modules",
+    "<%= app_path %>/bower_components",
+    <%- end -%>
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
To configure your Ember CLI Rails app to be ready to deploy on Heroku:

1. Run `rails g ember-cli:heroku` generator
1. [Add the NodeJS buildpack][buildpack] and configure NPM to include the
   `bower` dependency's executable file.

```sh
heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-nodejs
heroku config:set NPM_CONFIG_PRODUCTION=false
```

[buildpack]: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#adding-a-buildpack