### PR TITLE
Don't render `{head,body}.append` return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 master
 ------
 
+* `<%= head.append do %>` will now return `nil` so that accidentally using
+  `<%= %>` variety of ERB tags won't render the contents of the capture [#231]
+
+[#231]: https://github.com/thoughtbot/ember-cli-rails/pull/231
+
 0.4.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ To inject markup into page, pass in a block that accepts the `head`, and
 ```erb
 <!-- /app/views/application/index.html.erb -->
 <%= include_ember_index_html :frontend do |head| %>
-  <%= head.append do %>
+  <% head.append do %>
     <%= csrf_meta_tags %>
   <% end %>
 <% end %>

--- a/lib/ember-cli/capture.rb
+++ b/lib/ember-cli/capture.rb
@@ -9,7 +9,7 @@ module EmberCLI
 
     def capture
       if block.present?
-        capture_block
+        capture_content
       else
         SKIP_CAPTURE
       end
@@ -19,24 +19,24 @@ module EmberCLI
 
     attr_reader :block, :sprockets
 
-    def capture_block
+    def capture_content
       if block.arity > 0
         block.call(*block_arguments)
       end
 
-      [captured_head.content, captured_body.content]
+      [head.content, body.content]
     end
 
     def block_arguments
-      [captured_head, captured_body].first(block.arity)
+      [head, body].first(block.arity)
     end
 
-    def captured_body
-      @captured_body ||= Block.new(sprockets)
+    def body
+      @body ||= Block.new(sprockets)
     end
 
-    def captured_head
-      @captured_head ||= begin
+    def head
+      @head ||= begin
         if block.arity < 1
           BlockWithoutArguments.new(sprockets, &block)
         else
@@ -52,7 +52,7 @@ module EmberCLI
       end
 
       def content
-        @sprockets.capture(&@block)
+        @sprockets.with_output_buffer(&@block)
       end
     end
     private_constant :BlockWithoutArguments
@@ -64,7 +64,8 @@ module EmberCLI
       end
 
       def append(&block)
-        @content.push(@sprockets.capture(&block))
+        @content.push(@sprockets.with_output_buffer(&block))
+        nil
       end
 
       def content

--- a/spec/dummy/app/views/application/index.html.erb
+++ b/spec/dummy/app/views/application/index.html.erb
@@ -5,11 +5,11 @@
     <% end %>
   <% elsif params[:head_and_body] %>
     <%= include_ember_index_html "my-app" do |head, body| %>
-      <%= head.append do %>
+      <% head.append do %>
         <%= csrf_meta_tags %>
       <% end %>
 
-      <%= body.append do %>
+      <% body.append do %>
         <p>Hello from Rails</p>
       <% end %>
     <% end %>


### PR DESCRIPTION
`<%= head.append do %>` now returns `nil`.

Accidentally using the `<%= %>` variety of ERB tags will no longer
render the contents of the captured block as a plain text duplicate.