### PR TITLE
Remove `"CLI"` inflection

### DIFF
--- a/app/controllers/ember_tests_controller.rb
+++ b/app/controllers/ember_tests_controller.rb
@@ -18,7 +18,7 @@ class EmberTestsController < ActionController::Base
   end
 
   def app
-    EmberCLI[app_name]
+    EmberCli[app_name]
   end
 
   def app_name

--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -2,11 +2,11 @@ require "ember-cli/capture"
 
 module EmberRailsHelper
   def include_ember_index_html(name, &block)
-    markup_capturer = EmberCLI::Capture.new(sprockets: self, &block)
+    markup_capturer = EmberCli::Capture.new(sprockets: self, &block)
 
     head, body = markup_capturer.capture
 
-    html = EmberCLI[name].index_html(
+    html = EmberCli[name].index_html(
       sprockets: self,
       head: head,
       body: body,
@@ -16,10 +16,10 @@ module EmberRailsHelper
   end
 
   def include_ember_script_tags(name, **options)
-    javascript_include_tag(*EmberCLI[name].exposed_js_assets, options)
+    javascript_include_tag(*EmberCli[name].exposed_js_assets, options)
   end
 
   def include_ember_stylesheet_tags(name, **options)
-    stylesheet_link_tag(*EmberCLI[name].exposed_css_assets, options)
+    stylesheet_link_tag(*EmberCli[name].exposed_css_assets, options)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
-EmberCLI::Engine.routes.draw do
+EmberCli::Engine.routes.draw do
   get ":app_name", to: "ember_tests#index", format: false
 end

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -2,7 +2,7 @@ require File.expand_path("../lib/ember-cli/version", __FILE__)
 
 Gem::Specification.new do |spec|
   spec.name     = "ember-cli-rails"
-  spec.version  = EmberCLI::VERSION.dup
+  spec.version  = EmberCli::VERSION.dup
   spec.authors  = ["Pavel Pravosud", "Jonathan Jackson", "Sean Doyle"]
   spec.email    = ["pavel@pravosud.com", "jonathan.jackson1@me.com", "sean.p.doyle24@gmail.com"]
   spec.summary  = "Integration between Ember CLI and Rails"

--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -1,6 +1,6 @@
 require "ember-cli/engine" if defined?(Rails)
 
-module EmberCLI
+module EmberCli
   extend self
 
   autoload :App,           "ember-cli/app"
@@ -90,3 +90,5 @@ module EmberCLI
     Rails.configuration.middleware.use Middleware
   end
 end
+
+EmberCLI = EmberCli

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -2,7 +2,7 @@ require "timeout"
 require "ember-cli/html_page"
 require "ember-cli/asset_resolver"
 
-module EmberCLI
+module EmberCli
   class App
     ADDON_VERSION = "0.0.13"
     EMBER_CLI_VERSIONS = [ "~> 0.1.5", "~> 0.2.0", "~> 1.13" ]
@@ -37,7 +37,7 @@ module EmberCLI
 
       if bower_path.nil?
         fail <<-FAIL
-          Bower is required by EmberCLI.
+          Bower is required by EmberCLI
 
           Install it with:
 
@@ -154,7 +154,7 @@ module EmberCLI
     end
 
     def silence_build(&block)
-      if ENV.fetch("EMBER_CLI_RAILS_VERBOSE"){ EmberCLI.env.production? }
+      if ENV.fetch("EMBER_CLI_RAILS_VERBOSE") { EmberCli.env.production? }
         yield
       else
         silence_stream STDOUT, &block
@@ -162,11 +162,11 @@ module EmberCLI
     end
 
     def build_timeout
-      options.fetch(:build_timeout){ EmberCLI.configuration.build_timeout }
+      options.fetch(:build_timeout) { EmberCli.configuration.build_timeout }
     end
 
     def watcher
-      options.fetch(:watcher){ EmberCLI.configuration.watcher }
+      options.fetch(:watcher) { EmberCli.configuration.watcher }
     end
 
     def check_for_build_error!
@@ -294,7 +294,7 @@ module EmberCLI
     end
 
     def environment
-      EmberCLI.env.production?? "production" : "development"
+      EmberCli.env.production? ? "production" : "development"
     end
 
     def package_json

--- a/lib/ember-cli/asset_resolver.rb
+++ b/lib/ember-cli/asset_resolver.rb
@@ -1,4 +1,4 @@
-module EmberCLI
+module EmberCli
   class AssetResolver
     def initialize(app:, sprockets:)
       @app = app

--- a/lib/ember-cli/capture.rb
+++ b/lib/ember-cli/capture.rb
@@ -1,4 +1,4 @@
-module EmberCLI
+module EmberCli
   SKIP_CAPTURE = ["", ""].freeze
 
   class Capture

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -1,6 +1,6 @@
 require "singleton"
 
-module EmberCLI
+module EmberCli
   class Configuration
     include Singleton
 

--- a/lib/ember-cli/engine.rb
+++ b/lib/ember-cli/engine.rb
@@ -1,13 +1,7 @@
-module EmberCLI
+module EmberCli
   class Engine < Rails::Engine
-    initializer "ember-cli-rails.inflector" do
-      ActiveSupport::Inflector.inflections do |inflect|
-        inflect.acronym "CLI" if inflect.respond_to?(:acronym)
-      end
-    end
-
     initializer "ember-cli-rails.enable" do
-      EmberCLI.enable! unless EmberCLI.skip?
+      EmberCli.enable! unless EmberCli.skip?
     end
 
     initializer "ember-cli-rails.helpers" do

--- a/lib/ember-cli/helpers.rb
+++ b/lib/ember-cli/helpers.rb
@@ -1,4 +1,4 @@
-module EmberCLI
+module EmberCli
   module Helpers
     extend self
 

--- a/lib/ember-cli/html_page.rb
+++ b/lib/ember-cli/html_page.rb
@@ -1,4 +1,4 @@
-module EmberCLI
+module EmberCli
   class HtmlPage
     def initialize(content:, asset_resolver:, head: "", body: "")
       @content = content

--- a/lib/ember-cli/middleware.rb
+++ b/lib/ember-cli/middleware.rb
@@ -1,4 +1,4 @@
-module EmberCLI
+module EmberCli
   class Middleware
     def initialize(app)
       @app = app
@@ -10,7 +10,7 @@ module EmberCLI
       if path == "/testem.js"
         [ 200, { "Content-Type" => "text/javascript" }, [""] ]
       else
-        EmberCLI.process_path path
+        EmberCli.process_path path
         @app.call(env)
       end
     end

--- a/lib/ember-cli/path_set.rb
+++ b/lib/ember-cli/path_set.rb
@@ -1,4 +1,4 @@
-module EmberCLI
+module EmberCli
   class PathSet
     def self.define_path(name, &definition)
       define_method name do
@@ -30,11 +30,11 @@ module EmberCLI
     end
 
     define_path :dist do
-      EmberCLI.root.join("apps", app_name).tap(&:mkpath)
+      EmberCli.root.join("apps", app_name).tap(&:mkpath)
     end
 
     define_path :assets do
-      EmberCLI.root.join("assets").tap(&:mkpath)
+      EmberCli.root.join("assets").tap(&:mkpath)
     end
 
     define_path :applications do
@@ -99,7 +99,7 @@ module EmberCLI
     attr_reader :app
 
     delegate :name, :options, to: :app, prefix: true
-    delegate :configuration, to: EmberCLI
+    delegate :configuration, to: EmberCli
 
     def default_root
       Rails.root.join(app_name)

--- a/lib/ember-cli/runner.rb
+++ b/lib/ember-cli/runner.rb
@@ -1,4 +1,4 @@
-module EmberCLI
+module EmberCli
   class Runner
     TRUE_PROC = ->(*){ true }
 
@@ -11,7 +11,7 @@ module EmberCLI
     def process
       return if skip?
 
-      if EmberCLI.env.development?
+      if EmberCli.env.development?
         start_or_restart!
       else
         compile!

--- a/lib/ember-cli/version.rb
+++ b/lib/ember-cli/version.rb
@@ -1,3 +1,3 @@
-module EmberCLI
+module EmberCli
   VERSION = "0.4.1".freeze
 end

--- a/lib/generators/ember-cli/heroku/heroku_generator.rb
+++ b/lib/generators/ember-cli/heroku/heroku_generator.rb
@@ -1,4 +1,4 @@
-module EmberCLI
+module EmberCli
   class HerokuGenerator < Rails::Generators::Base
     source_root File.expand_path("../templates", __FILE__)
 
@@ -18,7 +18,7 @@ module EmberCLI
     end
 
     def app_paths
-      EmberCLI.apps.values.map do |app|
+      EmberCli.apps.values.map do |app|
         app.root.relative_path_from(Rails.root)
       end
     end

--- a/lib/generators/ember-cli/init/init_generator.rb
+++ b/lib/generators/ember-cli/init/init_generator.rb
@@ -1,4 +1,4 @@
-module EmberCLI
+module EmberCli
   class InitGenerator < Rails::Generators::Base
     source_root File.expand_path("../templates", __FILE__)
 

--- a/lib/generators/ember-cli/init/templates/initializer.rb
+++ b/lib/generators/ember-cli/init/templates/initializer.rb
@@ -1,3 +1,3 @@
-EmberCLI.configure do |c|
+EmberCli.configure do |c|
   c.app :frontend
 end

--- a/lib/tasks/ember-cli.rake
+++ b/lib/tasks/ember-cli.rake
@@ -1,21 +1,21 @@
 namespace :ember do
   desc "Runs `ember build` for each App"
   task compile: :install do
-    EmberCLI.compile!
+    EmberCli.compile!
   end
 
   desc "Runs `ember test` for each App"
   task test: :environment do
-    EmberCLI.run_tests!
+    EmberCli.run_tests!
   end
 
   desc "Installs each EmberCLI app's dependencies"
   task install: :environment do
-    EmberCLI.install_dependencies!
+    EmberCli.install_dependencies!
   end
 end
 
-unless EmberCLI.skip?
+unless EmberCli.skip?
   # Hook into assets:precompile:all for Rails 3.1+
   if Rails::VERSION::MAJOR < 4
     task "assets:precompile:all" => "ember:compile"

--- a/spec/dummy/config/initializers/ember.rb
+++ b/spec/dummy/config/initializers/ember.rb
@@ -1,3 +1,3 @@
-EmberCLI.configure do |c|
+EmberCli.configure do |c|
   c.app "my-app"
 end

--- a/spec/ember-cli/asset_resolver_spec.rb
+++ b/spec/ember-cli/asset_resolver_spec.rb
@@ -1,6 +1,6 @@
 require "ember-cli/asset_resolver"
 
-describe EmberCLI::AssetResolver do
+describe EmberCli::AssetResolver do
   describe "#resolve_urls" do
     context "substitues asset pipeline paths" do
       it "for application javascript" do
@@ -10,7 +10,7 @@ describe EmberCLI::AssetResolver do
           vendor_assets: ["vendor", "asset"],
         )
         sprockets = SprocketsMock.new
-        asset_resolver = EmberCLI::AssetResolver.new(
+        asset_resolver = EmberCli::AssetResolver.new(
           app: app,
           sprockets: sprockets,
         )

--- a/spec/ember-cli/html_page_spec.rb
+++ b/spec/ember-cli/html_page_spec.rb
@@ -1,9 +1,9 @@
-describe EmberCLI::HtmlPage do
+describe EmberCli::HtmlPage do
   describe "#render" do
     context "when <head> is present" do
       it "injects into the <head>" do
         content = valid_content
-        html_page = EmberCLI::HtmlPage.new(
+        html_page = EmberCli::HtmlPage.new(
           asset_resolver: build_asset_resolver(content),
           content: content,
           head: "injected!",
@@ -20,7 +20,7 @@ describe EmberCLI::HtmlPage do
     context "when <body> is present" do
       it "injects into the <body>" do
         content = valid_content
-        html_page = EmberCLI::HtmlPage.new(
+        html_page = EmberCli::HtmlPage.new(
           asset_resolver: build_asset_resolver(content),
           content: content,
           body: "injected!",
@@ -37,7 +37,7 @@ describe EmberCLI::HtmlPage do
     context "when the page isn't valid" do
       it "does nothing" do
         content = "<html></html>"
-        html_page = EmberCLI::HtmlPage.new(
+        html_page = EmberCli::HtmlPage.new(
           asset_resolver: build_asset_resolver(content),
           content: content,
           head: "injected!",
@@ -51,7 +51,7 @@ describe EmberCLI::HtmlPage do
     end
 
     def build_asset_resolver(content)
-      resolver = double("EmberCLI::AssetResolver")
+      resolver = double("EmberCli::AssetResolver")
       allow(resolver).
         to receive(:resolve_urls).
         with(content).


### PR DESCRIPTION
Closes [#151].

> Due to [rails/rails#17879] and (the [inflection] definition) we
> started seeing addresses in our system render as
>

```
123 Example Street, North CLI Ffe WA
```

> Instead of

```
123 Example Street, NORTHCLIFFE WA
```
> when we used `.titleize` or similar.


To fix this, we'll use the `EmberCli` module in our implementation. To
ensure backward compatibility, we'll alias the `EmberCli` module to
`EmberCLI`.

[inflection]: https://github.com/rwz/ember-cli-rails/blob/master/lib/ember-cli/engine.rb#L5
[#151]: https://github.com/thoughtbot/ember-cli-rails/issues/151
[rails/rails#17879]: https://github.com/rails/rails/issues/17879