### PR TITLE
Fail the process if `exec` fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 master
 ------
 
+* Failures in `{bundle,npm,bower} install` will now fail the host process with a
+  non-zero exit status. [#236]
 * Improve error reporting:
   Redirect `ember build` from `$STDERR` to the build error file. [#245]
 
+[#236]: https://github.com/thoughtbot/ember-cli-rails/pull/236
 [#245]: https://github.com/thoughtbot/ember-cli-rails/pull/245
 
 0.4.2

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -60,7 +60,8 @@ module EmberCli
 
     def run_tests
       prepare
-      exit 1 unless exec("#{ember_path} test")
+
+      exec("#{ember_path} test")
     end
 
     def stop
@@ -343,7 +344,7 @@ module EmberCli
 
     def exec(cmd, method: :system)
       Dir.chdir root do
-        Kernel.public_send(method, env_hash, cmd, err: :out)
+        Kernel.public_send(method, env_hash, cmd, err: :out) || exit(1)
       end
     end
 


### PR DESCRIPTION
When running `install_dependencies` or `compile`, failures won't halt
the host program.

This could lead to false positives and difficult to debug scenarios.

Consumers would prefer this to fail as early on as possible.