### PR TITLE
Turn off JS Minification for Heroku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Disable JS minification when generating Heroku setup [#238]
 * `BuildError#message` includes first line of backtrace. [#256]
 * Exposes `build_timeout` configuration as `ENV["EMBER_BUILD_TIMEOUT"]`.
 * Change default `build_timeout` to `15` seconds.
@@ -9,6 +10,7 @@ master
 * `manifest.json`. Since we now defer to EmberCLI, we no longer need to
   manually resolve asset URLs. [#250]
 
+[#238]: https://github.com/thoughtbot/ember-cli-rails/pull/238
 [#256]: https://github.com/thoughtbot/ember-cli-rails/pull/256
 [#250]: https://github.com/thoughtbot/ember-cli-rails/pull/250
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,21 @@ $ heroku config:unset SKIP_EMBER
 
 You should be ready to deploy.
 
+The generator will disable Rails' JavaScript compression by declaring:
+
+```rb
+config.assets.js_compressor = nil
+```
+
+This is recommended, but might not work for projects that have both Asset
+Pipeline and EmberCLI generated JavaScript.
+
+To reverse this change, reconfigure Sprockets to use the `uglifier` gem:
+
+```rb
+config.assets.js_compressor = :uglifier
+```
+
 **NOTE** Run the generator each time you introduce additional EmberCLI
 applications into the project.
 

--- a/lib/generators/ember-cli/heroku/heroku_generator.rb
+++ b/lib/generators/ember-cli/heroku/heroku_generator.rb
@@ -13,6 +13,16 @@ module EmberCli
       run "chmod a+x bin/heroku_install"
     end
 
+    def config_js_compressor
+      production_config = "config/environments/production.rb"
+
+      inject_into_file production_config, before: "end\n" do
+        <<-RUBY
+  config.assets.js_compressor = nil
+        RUBY
+      end
+    end
+
     def inject_12factor_gem
       gem "rails_12factor", group: [:staging, :production]
     end


### PR DESCRIPTION
Given the outcome of [#123] and [#124], we don't take a stand on where
minification should happen.

However, to make sure that Heroku deployments don't take too long, the
generator can disable Rails-side minification.

The benefit of doing this in the generator (as opposed to automatically
in [the addon]) is that the change will introduce diff noise, which is
explicit and easy to back out of.

[#123]: https://github.com/thoughtbot/ember-cli-rails/pull/123
[#124]: https://github.com/thoughtbot/ember-cli-rails/pull/124
[the addon]: https://github.com/rondale-sc/ember-cli-rails-addon/blob/2f2a47efe6e81a2bcd43ec9ff0f89fc18bed5a03/index.js#L25-L32