### PR TITLE
Change allows ember-cli-rails to work under jruby-9.0.3.0 

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -339,7 +339,7 @@ module EmberCli
 
     def exec(cmd, method: :system)
       Dir.chdir root do
-        Kernel.public_send(method, env_hash, cmd, err: :out)
+        Kernel.public_send(method, env_hash, cmd)
       end
     end
 


### PR DESCRIPTION
There may be a better fix for this. I doubt that this change should be merged as it is. 

Without this change, I get an error after running app.rb line 44:
    @pid = exec(cmd, method: :spawn)

Using ruby-2.2.2 there is no problem. With 'rvm use jruby-9.0.3.0' the error is as follows : 

Java::JavaLang::ArrayIndexOutOfBoundsException (-2):
  org.jruby.util.io.PopenExecutor.run_exec_dup2(PopenExecutor.java:789)
  org.jruby.util.io.PopenExecutor.execargRunOptions(PopenExecutor.java:986)
  org.jruby.util.io.PopenExecutor.spawnProcess(PopenExecutor.java:113)
  org.jruby.util.io.PopenExecutor.spawn(PopenExecutor.java:75)
  org.jruby.RubyProcess.spawn(RubyProcess.java:1296)
  org.jruby.RubyKernel.spawn(RubyKernel.java:1509)
...