### PR TITLE
Disable SelectorFormat for hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,4 @@
 scss_files: "**/*.scss"
 linters:
-  NameFormat:
-    enabled: false
+  SelectorFormat:
+    convention: "hyphenated_BEM"

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+scss_files: "**/*.scss"
+linters:
+  NameFormat:
+    enabled: false

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,4 @@
 scss_files: "**/*.scss"
 linters:
   SelectorFormat:
-    enabled: true
-    convention: hyphenated_BEM
+    enabled: false

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,5 @@
 scss_files: "**/*.scss"
 linters:
   SelectorFormat:
-    convention: "hyphenated_BEM"
+    enabled: true
+    convention: hyphenated_BEM

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -6,3 +6,7 @@ body {
 img {
   max-width: 100%;
 }
+
+.this__is-a--test {
+  color: red;
+}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -8,5 +8,5 @@ img {
 }
 
 .this__is-a--test {
-  color: red;
+  color: #000;
 }


### PR DESCRIPTION
When using BEM, Hound complains about everything. I am attempting to
completely disable the NameFormat because I have not found a convention
that works with BEM.