### PR TITLE
Raise Error on `ember build` death

### DIFF
--- a/lib/ember-cli/path_set.rb
+++ b/lib/ember-cli/path_set.rb
@@ -74,6 +74,10 @@ module EmberCli
       tmp.join("error.txt")
     end
 
+    define_path :ember_stderr_file do
+      tmp.join("stderr.txt")
+    end
+
     define_path :tee do
       app_options.fetch(:tee_path){ configuration.tee_path }
     end


### PR DESCRIPTION
Initial steps toward closing [#240].

When checking for the existence of an `ember-cli-rails-addon` managed
error file, also make sure the spawned `ember build --watch` process is
still running.

Unfortunately, [ember-cli-dependency-checker]'s errors aren't currently
logged to `process.stderr`, so the `ProcessDeathError`'s stack trace is
empty.

Once `ember-cli` properly logs the Errors to `stderr`, the stack trace
will be more meaningful.

Depends on ember-cli/ember-cli#5038

[ember-cli-dependency-checker]: https://github.com/quaertym/ember-cli-dependency-checker
[#240]: https://github.com/thoughtbot/ember-cli-rails/issues/240
