### PR TITLE
Redirect `ember build` errors to error file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 master
 ------
 
+* Improve error reporting:
+  Redirect `ember build` from `$STDERR` to the build error file. [#245]
+
+[#245]: https://github.com/thoughtbot/ember-cli-rails/pull/245
+
 0.4.2
 -----
 

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -178,12 +178,12 @@ module EmberCli
     end
 
     def build_error?
-      build_error_file_path.exist?
+      build_error_file_path.exist? && build_error_file_path.size?
     end
 
     def raise_build_error!
       error = BuildError.new("EmberCLI app #{name.inspect} has failed to build")
-      error.set_backtrace build_error_file_path.read.split(?\n)
+      error.set_backtrace build_error_file_path.readlines
       fail error
     end
 
@@ -282,7 +282,11 @@ module EmberCli
         end
       end
 
-      "#{ember_path} build #{watch_flag} --environment #{environment} --output-path #{dist_path} #{log_pipe}"
+      "#{ember_path} build #{watch_flag} --environment #{environment} --output-path #{dist_path} #{redirect_errors} #{log_pipe}"
+    end
+
+    def redirect_errors
+      "2> #{build_error_file_path}"
     end
 
     def log_pipe


### PR DESCRIPTION
Initial steps toward closing [#240].

Pipe `ember build` errors from `$STDERR` to `ember-cli-rails`'s build
error file.

Depends on [ember-cli/ember-cli#5038]

[#240]: https://github.com/thoughtbot/ember-cli-rails/issues/240
[ember-cli/ember-cli#5038]: https://github.com/ember-cli/ember-cli/issues/5038