### PR TITLE
Update jekyll and add jekyll-watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.jekyll-metadata
 .sass-cache/
 _site/

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gem "bourbon"
+gem "jekyll"
+gem "jekyll-watch"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,32 @@ GEM
     bourbon (4.2.6)
       sass (~> 3.4)
       thor (~> 0.19)
+    colorator (0.1)
+    ffi (1.9.10)
+    jekyll (3.0.0)
+      colorator (~> 0.1)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.3.0)
+      sass (~> 3.2)
+    jekyll-watch (1.3.0)
+      listen (~> 3.0)
+    kramdown (1.8.0)
+    liquid (3.0.6)
+    listen (3.0.3)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    rb-fsevent (0.9.6)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rouge (1.10.1)
+    safe_yaml (1.0.4)
     sass (3.4.19)
     thor (0.19.1)
 
@@ -12,6 +38,8 @@ PLATFORMS
 
 DEPENDENCIES
   bourbon
+  jekyll
+  jekyll-watch
 
 BUNDLED WITH
    1.10.6

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-gems: [bourbon]
+gems: [bourbon, jekyll, jekyll-watch]


### PR DESCRIPTION
The production build is failing with the following error:

```
The file `stylesheets/styles.scss` contains syntax errors. For more information, see
 https://help.github.com/articles/page-build-failed-markdown-errors.
```

I am unable to produce this locally, so we are attempting to fix this with an update to jekyll.
