### PR TITLE
Change default `build_timeout` to 15 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Exposes `build_timeout` configuration as `ENV["EMBER_BUILD_TIMEOUT"]`.
+* Change default `build_timeout` to `15` seconds.
 * Symlink `dist/` directly to Asset Pipeline [#250]
 * Merge EmberCLI-generated `manifest.json` into Sprocket's [#250]
 * `manifest.json`. Since we now defer to EmberCLI, we no longer need to

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ end
 - `app` - this represents the name of the Ember CLI application.
 
 - `build_timeout` - seconds to allow Ember to build the application before
-  timing out
+  timing out. Defaults to `ENV["EMBER_BUILD_TIMEOUT"]`, which falls back to
+  `15`.
 
 - `path` - the path where your Ember CLI application is located. The default
   value is the name of your app in the Rails root.
@@ -443,6 +444,13 @@ if (environment === 'development') {
 `RAILS_ENV` will be absent in production builds.
 
 [ember-cli-mirage]: http://ember-cli-mirage.com/docs/latest/
+
+### `EMBER_BUILD_TIMEOUT`
+
+Number of seconds to wait before timing out a local build.
+
+If the environment variable isn't declared, the `build_timeout` will default to
+`15`.
 
 ### `SKIP_EMBER`
 

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -30,7 +30,7 @@ module EmberCli
     end
 
     def build_timeout
-      @build_timeout ||= 5
+      @build_timeout ||= ENV.fetch("EMBER_BUILD_TIMEOUT", 15).to_i
     end
 
     attr_writer :build_timeout


### PR DESCRIPTION
When handling views that use `include_ember_index_html`, the initial
request requires the `index.html` to be built and present.

The previous default value of `5` seconds isn't sufficient for the
request to kick off the build process and wait until completion.

To avoid confusion (and extra :arrows_counterclockwise: button clicks`),
we'll increase the timeout to `15` seconds.

Additionally, we'll expose the `EMBER_BUILD_TIMEOUT` environment
variable. Teams running on slower hardware can increase the timeout to a
better value without introducing git diff noise and churn.