### PR TITLE
Build Error includes first line of backtrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* `BuildError#message` includes first line of backtrace. [#256]
 * Exposes `build_timeout` configuration as `ENV["EMBER_BUILD_TIMEOUT"]`.
 * Change default `build_timeout` to `15` seconds.
 * Symlink `dist/` directly to Asset Pipeline [#250]
@@ -8,6 +9,7 @@ master
 * `manifest.json`. Since we now defer to EmberCLI, we no longer need to
   manually resolve asset URLs. [#250]
 
+[#256]: https://github.com/thoughtbot/ember-cli-rails/pull/256
 [#250]: https://github.com/thoughtbot/ember-cli-rails/pull/250
 
 0.4.3

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -184,8 +184,12 @@ module EmberCli
     end
 
     def raise_build_error!
-      error = BuildError.new("EmberCLI app #{name.inspect} has failed to build")
-      error.set_backtrace build_error_file_path.readlines
+      backtrace = build_error_file_path.readlines.reject(&:blank?)
+      message = "#{name.inspect} has failed to build: #{backtrace.first}"
+
+      error = BuildError.new(message)
+      error.set_backtrace(backtrace)
+
       fail error
     end
 


### PR DESCRIPTION
[rails/web-console] is meant to display Ruby errors.

When presented with JS stack traces, or free text CLI error messages, it
confusingly displays a large (almost to the fold) white console box.

To make it more obvious what the client-side error was, we include the
first line of the backtrace in the `BuildError`'s message.

[rails/web-console]: https://github.com/rails/web-console