### PR TITLE
Remove `build_timeout` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 master
 ------
 
+* Remove `build_timeout` configuration [#259]
 * Disable JS minification when generating Heroku setup [#238]
 * `BuildError#message` includes first line of backtrace. [#256]
-* Exposes `build_timeout` configuration as `ENV["EMBER_BUILD_TIMEOUT"]`.
-* Change default `build_timeout` to `15` seconds.
 * Symlink `dist/` directly to Asset Pipeline [#250]
 * Merge EmberCLI-generated `manifest.json` into Sprocket's [#250]
 * `manifest.json`. Since we now defer to EmberCLI, we no longer need to
   manually resolve asset URLs. [#250]
 
+[#259]: https://github.com/thoughtbot/ember-cli-rails/pull/259
 [#238]: https://github.com/thoughtbot/ember-cli-rails/pull/238
 [#256]: https://github.com/thoughtbot/ember-cli-rails/pull/256
 [#250]: https://github.com/thoughtbot/ember-cli-rails/pull/250

--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ end
 
 - `app` - this represents the name of the Ember CLI application.
 
-- `build_timeout` - seconds to allow Ember to build the application before
-  timing out. Defaults to `ENV["EMBER_BUILD_TIMEOUT"]`, which falls back to
-  `15`.
-
 - `path` - the path where your Ember CLI application is located. The default
   value is the name of your app in the Rails root.
 
@@ -130,16 +126,6 @@ To inject markup into page, pass in a block that accepts the `head`, and
 ```
 
 The asset paths will be replaced with asset pipeline generated paths.
-
-*NOTE*
-
-This helper **requires** that the `index.html` file exists.
-
-If you see `Errno::ENOENT` errors in development, your requests are timing out
-before EmberCLI finishes compiling the application.
-
-To prevent race conditions, increase your `build_timeout` to ensure that the
-build finishes before your request is processed.
 
 ### Rendering the EmberCLI generated JS and CSS
 
@@ -474,13 +460,6 @@ if (environment === 'development') {
 `RAILS_ENV` will be absent in production builds.
 
 [ember-cli-mirage]: http://ember-cli-mirage.com/docs/latest/
-
-### `EMBER_BUILD_TIMEOUT`
-
-Number of seconds to wait before timing out a local build.
-
-If the environment variable isn't declared, the `build_timeout` will default to
-`15`.
 
 ### `SKIP_EMBER`
 

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -1,4 +1,3 @@
-require "timeout"
 require "non-stupid-digest-assets"
 require "ember-cli/html_page"
 
@@ -99,33 +98,7 @@ module EmberCli
     end
 
     def wait
-      Timeout.timeout(build_timeout) do
-        wait_for_build_complete_or_error
-      end
-    rescue Timeout::Error
-      suggested_timeout = build_timeout + 5
-
-      warn <<-MSG.strip_heredoc
-        ============================= WARNING! =============================
-
-          Seems like Ember #{name} application takes more than #{build_timeout}
-          seconds to compile.
-
-          To prevent race conditions consider adjusting build timeout
-          configuration in your ember initializer:
-
-            EmberCLI.configure do |config|
-              config.build_timeout = #{suggested_timeout} # in seconds
-            end
-
-          Alternatively, you can set build timeout per application like this:
-
-            EmberCLI.configure do |config|
-              config.app :#{name}, build_timeout: #{suggested_timeout}
-            end
-
-        ============================= WARNING! =============================
-      MSG
+      wait_for_build_complete_or_error
     end
 
     def method_missing(method_name, *)
@@ -161,10 +134,6 @@ module EmberCli
       else
         silence_stream STDOUT, &block
       end
-    end
-
-    def build_timeout
-      options.fetch(:build_timeout) { EmberCli.configuration.build_timeout }
     end
 
     def watcher

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -5,6 +5,10 @@ module EmberCli
     include Singleton
 
     def app(name, **options)
+      if options.has_key? :build_timeout
+        deprecate_timeout
+      end
+
       apps.store name, App.new(name, options)
     end
 
@@ -29,11 +33,23 @@ module EmberCli
       @bundler_path ||= Helpers.which("bundler")
     end
 
-    def build_timeout
-      @build_timeout ||= ENV.fetch("EMBER_BUILD_TIMEOUT", 15).to_i
+    def build_timeout=(*)
+      deprecate_timeout
     end
 
-    attr_writer :build_timeout
     attr_accessor :watcher
+
+    private
+
+    def deprecate_timeout
+      warn <<-WARN.strip_heredoc
+
+      The `build_timeout` configuration has been removed.
+
+      Please read https://github.com/thoughtbot/ember-cli-rails/pull/259 for
+      details.
+
+      WARN
+    end
   end
 end


### PR DESCRIPTION
The future use cases of this project expect that the build will complete
before serving the Ember applications.

Additionally, build timeouts used to act as a workaround for when
the EmberCLI build had errors that weren't being communicated to the
Rails process. Now that [EmberCLI writes errors to STDERR][stderr],
which EmberCLI-Rails [pipes STDERR to a file][pipe] for monitoring,
EmberCLI build errors will be raised by the Rails process.

For Users who care about timeouts, [rack-timeout] serves as a great
alternative.

[stderr]: https://github.com/ember-cli/ember-cli/pull/5039
[pipe]: https://github.com/thoughtbot/ember-cli-rails/pull/245
[rack-timeout]: https://github.com/heroku/rack-timeout