### PR TITLE
Deprecate the `:enable` initializer option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Remove `enable` configuration in favor of using `mount_ember_app`.  [#261]
 * Introduce `mount_ember_app` route helper [#262]
 * Remove support for viewing Ember tests through Rails. Instead, use `ember
   test` or `ember test --serve` from within the Ember directory. [#264]
@@ -18,6 +19,7 @@ master
 [#238]: https://github.com/thoughtbot/ember-cli-rails/pull/238
 [#256]: https://github.com/thoughtbot/ember-cli-rails/pull/256
 [#250]: https://github.com/thoughtbot/ember-cli-rails/pull/250
+[#261]: https://github.com/thoughtbot/ember-cli-rails/pull/261
 
 0.4.3
 -----

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Without it you'll receive a `422 Unprocessable Entity` error, specifically: `Act
 
 In order to add that token to your requests, you need to add into your template:
 
+```erb
 <!-- app/views/application/index.html.erb -->
 <%= include_ember_index_html :frontend do |head| %>
   <% head.append do %>

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -207,12 +207,11 @@ module EmberCli
     def check_dependencies!
       unless node_modules_present?
         fail <<-MSG.strip_heredoc
-          EmberCLI app dependencies are not installed. From your Rails application root please run:
+          EmberCLI app dependencies are not installed.
+          From your Rails application root please run:
 
             $ bundle exec rake ember:install
 
-          If you do not require Ember at this URL, you can restrict this check using the `enable`
-          option in the EmberCLI initializer.
         MSG
       end
     end

--- a/lib/ember-cli/configuration.rb
+++ b/lib/ember-cli/configuration.rb
@@ -9,6 +9,10 @@ module EmberCli
         deprecate_timeout
       end
 
+      if options.has_key? :enable
+        deprecate_enable
+      end
+
       apps.store name, App.new(name, options)
     end
 
@@ -40,6 +44,17 @@ module EmberCli
     attr_accessor :watcher
 
     private
+
+    def deprecate_enable
+      warn <<-WARN.strip_heredoc
+
+      The `enable` lambda configuration has been removed.
+
+      Please read https://github.com/thoughtbot/ember-cli-rails/pull/261 for
+      details.
+
+      WARN
+    end
 
     def deprecate_timeout
       warn <<-WARN.strip_heredoc

--- a/lib/ember-cli/runner.rb
+++ b/lib/ember-cli/runner.rb
@@ -1,7 +1,5 @@
 module EmberCli
   class Runner
-    TRUE_PROC = ->(*){ true }
-
     attr_reader :app, :path
 
     def initialize(app, path)
@@ -9,8 +7,6 @@ module EmberCli
     end
 
     def process
-      return if skip?
-
       if EmberCli.env.development?
         start_or_restart!
       else
@@ -21,11 +17,6 @@ module EmberCli
     end
 
     private
-
-    def skip?
-      invoker = app.options.fetch(:enable, TRUE_PROC)
-      !invoker.call(path)
-    end
 
     def start_or_restart!
       run! unless app.pid && still_running?


### PR DESCRIPTION
The `enable` option was meant to provide users with a means of skipping
Ember compilation when TDDing API endpoints.

This commit removes the option, deferring Ember request detection
to the `mount_ember_app` at the routing layer.