### PR TITLE
Introduce `mount_ember_app` route helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 master
 ------
 
+* Introduce `mount_ember_app` route helper [#262]
 * Remove support for viewing Ember tests through Rails. Instead, use `ember
-  test` or `ember test --serve` from within the Ember directory.
+  test` or `ember test --serve` from within the Ember directory. [#264]
 * Remove `build_timeout` configuration [#259]
 * Disable JS minification when generating Heroku setup [#238]
 * `BuildError#message` includes first line of backtrace. [#256]
@@ -11,6 +12,8 @@ master
 * `manifest.json`. Since we now defer to EmberCLI, we no longer need to
   manually resolve asset URLs. [#250]
 
+[#264]: https://github.com/thoughtbot/ember-cli-rails/pull/264
+[#262]: https://github.com/thoughtbot/ember-cli-rails/pull/262
 [#259]: https://github.com/thoughtbot/ember-cli-rails/pull/259
 [#238]: https://github.com/thoughtbot/ember-cli-rails/pull/238
 [#256]: https://github.com/thoughtbot/ember-cli-rails/pull/256

--- a/app/views/ember_cli/ember/index.html.erb
+++ b/app/views/ember_cli/ember/index.html.erb
@@ -1,0 +1,5 @@
+<%= include_ember_index_html @app do |head| %>
+  <% head.append do %>
+    <%= csrf_meta_tags %>
+  <% end %>
+<% end %>

--- a/lib/ember-cli/constraint.rb
+++ b/lib/ember-cli/constraint.rb
@@ -1,0 +1,9 @@
+module EmberCli
+  class Constraint
+    def matches?(request)
+      matches = request.format.to_s =~ /html/ || -1
+
+      matches > -1
+    end
+  end
+end

--- a/lib/ember-cli/controller_extension.rb
+++ b/lib/ember-cli/controller_extension.rb
@@ -1,0 +1,11 @@
+module EmberCli
+  module ControllerExtension
+    def self.included(base)
+      base.before_action do
+        if params.has_key?(:ember_app)
+          EmberCli.process_path(request.path_info)
+        end
+      end
+    end
+  end
+end

--- a/lib/ember-cli/ember_controller.rb
+++ b/lib/ember-cli/ember_controller.rb
@@ -1,0 +1,9 @@
+module EmberCli
+  class EmberController < ::ApplicationController
+    def index
+      @app = params[:ember_app]
+
+      render layout: false
+    end
+  end
+end

--- a/lib/ember-cli/engine.rb
+++ b/lib/ember-cli/engine.rb
@@ -1,12 +1,23 @@
 module EmberCli
   class Engine < Rails::Engine
+    initializer "ember-cli-rails.rendering" do
+      require "ember-cli/ember_controller"
+      require "ember-cli/route_helpers"
+    end
+
     initializer "ember-cli-rails.enable" do
       EmberCli.enable! unless EmberCli.skip?
     end
 
-    initializer "ember-cli-rails.helpers" do
-      config.to_prepare do
-        ActionController::Base.helper EmberRailsHelper
+    config.to_prepare do
+      ActionController::Base.helper EmberRailsHelper
+    end
+
+    config.after_initialize do
+      if defined?(ApplicationController)
+        require "ember-cli/controller_extension"
+
+        ApplicationController.include(EmberCli::ControllerExtension)
       end
     end
   end

--- a/lib/ember-cli/middleware.rb
+++ b/lib/ember-cli/middleware.rb
@@ -10,7 +10,6 @@ module EmberCli
       if path == "/testem.js"
         [ 200, { "Content-Type" => "text/javascript" }, [""] ]
       else
-        EmberCli.process_path path
         @app.call(env)
       end
     end

--- a/lib/ember-cli/route_helpers.rb
+++ b/lib/ember-cli/route_helpers.rb
@@ -1,0 +1,25 @@
+require "ember-cli/constraint"
+
+module ActionDispatch
+  module Routing
+    class Mapper
+      def mount_ember_app(app_name, to:, **options)
+        routing_options = options.deep_merge(
+          defaults: { ember_app: app_name },
+        )
+
+        routing_options.reverse_merge!(
+          controller: "ember_cli/ember",
+          action: "index",
+          format: :html,
+        )
+
+        Rails.application.routes.draw do
+          scope constraints: EmberCli::Constraint.new do
+            get("#{to}(*rest)", routing_options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,34 @@
 Rails.application.routes.draw do
-  root to: "application#index"
+  mount_ember_app(
+    "my-app",
+    to: "/empty-block",
+    controller: "high_voltage/pages",
+    action: "show",
+    id: "include_index_empty_block",
+    as: "include_index_empty_block",
+  )
+
+  mount_ember_app(
+    "my-app",
+    to: "/head-and-body-block",
+    controller: "high_voltage/pages",
+    action: "show",
+    id: "include_index_head_and_body",
+    as: "include_index_head_and_body",
+  )
+
+  mount_ember_app(
+    "my-app",
+    to: "/asset-helpers",
+    controller: "high_voltage/pages",
+    action: "show",
+    id: "embedded",
+    as: "embedded",
+  )
+
+  mount_ember_app(
+    "my-app",
+    to: "/",
+    as: "default",
+  )
 end

--- a/spec/features/user_views_ember_app_spec.rb
+++ b/spec/features/user_views_ember_app_spec.rb
@@ -1,28 +1,32 @@
 feature "User views ember app", :js do
-  scenario "with asset helpers" do
-    visit page_path("embedded")
+  scenario "using route helper" do
+    visit default_path
 
     expect(page).to have_client_side_asset
     expect(page).to have_javascript_rendered_text
+    expect(page).to have_csrf_tags
   end
 
-  scenario "with index helper" do
-    visit page_path("include_index")
+  context "using custom controller" do
+    scenario "rendering with asset helpers" do
+      visit embedded_path
 
-    expect(page).to have_client_side_asset
-    expect(page).to have_javascript_rendered_text
-    expect(page).to have_no_csrf_tags
+      expect(page).to have_client_side_asset
+      expect(page).to have_javascript_rendered_text
+    end
 
-    visit page_path("include_index_empty_block")
+    scenario "rendering with index helper" do
+      visit include_index_empty_block_path
 
-    expect(page).to have_javascript_rendered_text
-    expect(page).to have_csrf_tags
+      expect(page).to have_javascript_rendered_text
+      expect(page).to have_csrf_tags
 
-    visit page_path("include_index_head_and_body")
+      visit include_index_head_and_body_path
 
-    expect(page).to have_javascript_rendered_text
-    expect(page).to have_csrf_tags
-    expect(page).to have_rails_injected_text
+      expect(page).to have_javascript_rendered_text
+      expect(page).to have_csrf_tags
+      expect(page).to have_rails_injected_text
+    end
   end
 
   def have_client_side_asset

--- a/spec/lib/ember-cli/constraint_spec.rb
+++ b/spec/lib/ember-cli/constraint_spec.rb
@@ -1,0 +1,34 @@
+require "ember-cli/constraint"
+
+describe EmberCli::Constraint do
+  describe "#matches?" do
+    context %{when the format is "html"} do
+      it "return true" do
+        constraint = EmberCli::Constraint.new
+        request = double(format: :html)
+
+        expect(constraint.matches?(request)).to be true
+      end
+    end
+
+    context %{when the format isn't "html"} do
+      it "return false" do
+        constraint = EmberCli::Constraint.new
+        request = double(format: :json)
+
+        expect(constraint.matches?(request)).to be false
+      end
+    end
+
+    context %"when the format is empty or nil" do
+      it "return false" do
+        constraint = EmberCli::Constraint.new
+        nil_request = double(format: nil)
+        empty_request = double(format: "")
+
+        expect(constraint.matches?(nil_request)).to be false
+        expect(constraint.matches?(empty_request)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Abstract away the details of routing to an ember application.

To configure Rails to route requests to the `frontend` Ember
application:

```rb

Rails.application.routes.draw do
  mount_ember_app :frontend, to: "/"
end
```

Ember requests will be set `params[:ember_app]` to the name of the application.
In the above example, `params[:ember_app] == :frontend`.

**Routing options**

* `path` - The path to handle as an Ember application. This will only apply to
  `format: :html` requests. Additionally, this will handle child routes as well.
  For instance, mounting `mount_ember_app :frontend, to: "/frontend"` will handle a
  `format: :html` request to `/frontend/posts`.
* `controller` - Defaults to `"ember_cli/ember"`
* `action` - Defaults to `"index"`

You should now be able to boot your Rails application, navigate to the `root`
route, and see your EmberCLI app!

By default, routes defined by `ember_app` will be rendered with the internal
`EmberCli::EmberController`. The `EmberCli::EmberController` renders the Ember
application's `index.html` and injects the Rails-generated CSRF tags into the
`<head>`.

To override this behavior, specify the `controller` and `action` options:

```rb

Rails.application.routes.draw do
  mount_ember_app :frontend, to: "/", controller: "application", action: "index"
end
```

To serve the EmberCLI generated `index.html`, use the `include_ember_index_html`
helper in your view:

```erb
<!-- app/views/application/index.html.erb -->
<%= include_ember_index_html :frontend %>
```

To inject markup into page, pass in a block that accepts the `head`, and
(optionally) the `body`:

```erb
<!-- app/views/application/index.html.erb -->
<%= include_ember_index_html :frontend do |head| %>
  <% head.append do %>
    <%= csrf_meta_tags %>
  <% end %>
<% end %>
```

When serving the EmberCLI generated `index.html`, don't use Rails' layout HTML:

```rb
class ApplicationController < ActionController::Base
  def index
    render layout: false
  end
end
```

In addition to rendering the EmberCLI generated `index.html`, you can inject the
`<script>` and `<link>` tags into your Rails generated views:

```erb
<!-- app/views/application/index.html.erb -->
<%= include_ember_script_tags :frontend %>
<%= include_ember_stylesheet_tags :frontend %>