### PR TITLE
Remove `EmberCli::App#method_missing`

### DIFF
--- a/lib/ember-cli/path_set.rb
+++ b/lib/ember-cli/path_set.rb
@@ -45,6 +45,10 @@ module EmberCli
       ember_cli_root.join("assets").tap(&:mkpath)
     end
 
+    define_path :app_assets do
+      assets.join(app_name)
+    end
+
     define_path :applications do
       rails_root.join("public", "_apps").tap(&:mkpath)
     end

--- a/spec/lib/ember-cli/path_set_spec.rb
+++ b/spec/lib/ember-cli/path_set_spec.rb
@@ -61,6 +61,16 @@ describe EmberCli::PathSet do
     end
   end
 
+  describe "#app_assets" do
+    it "is a child of #assets" do
+      app = double(name: "bar")
+      path_set = build_path_set(app: app)
+
+      expect(path_set.app_assets).
+        to eq ember_cli_root.join("assets").join("bar")
+    end
+  end
+
   describe "#applications" do
     it "is a child of #rails_root" do
       path_set = build_path_set


### PR DESCRIPTION
Make `EmberCli::App` simpler by removing clever `method_missing`
approach to paths.

Instead of delegating `_path` methods to the `PathSet`, make their
invocations explicit.