### PR TITLE
No longer check dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 master
 ------
 
+* No longer check dependencies within the app. Defer to EmberCLI's `stderr`
+  streaming. [#267]
 * Remove `enable` configuration in favor of using `mount_ember_app`.  [#261]
-* Introduce `mount_ember_app` route helper [#262]
+* Introduce `mount_ember_app` route helper [#263]
 * Remove support for viewing Ember tests through Rails. Instead, use `ember
   test` or `ember test --serve` from within the Ember directory. [#264]
 * Remove `build_timeout` configuration [#259]
@@ -13,8 +15,9 @@ master
 * `manifest.json`. Since we now defer to EmberCLI, we no longer need to
   manually resolve asset URLs. [#250]
 
+[#267]: https://github.com/thoughtbot/ember-cli-rails/pull/267
 [#264]: https://github.com/thoughtbot/ember-cli-rails/pull/264
-[#262]: https://github.com/thoughtbot/ember-cli-rails/pull/262
+[#263]: https://github.com/thoughtbot/ember-cli-rails/pull/263
 [#259]: https://github.com/thoughtbot/ember-cli-rails/pull/259
 [#238]: https://github.com/thoughtbot/ember-cli-rails/pull/238
 [#256]: https://github.com/thoughtbot/ember-cli-rails/pull/256

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You should still be able leverage the asset pipeline, and all the conveniences
 that Rails offers. And you should get all the new goodies like ES6 modules and
 Ember CLI addons too! Without further ado, let's get in there!
 
+**EmberCLI-Rails Supports EmberCLI 1.13.x and later.**
+
 ## Installation
 
 Add the following to your `Gemfile`:
@@ -94,7 +96,22 @@ $ cd path/to/frontend
 $ npm install --save-dev ember-cli-rails-addon
 ```
 
+Be sure that the addon's [`MAJOR` and `MINOR` version][semver] matches the gem's
+`MAJOR` and `MINOR` versions.
+
+For instance, if you're using the `0.5.x` version of the gem, specify
+`~> 0.5.0` ion in your Ember app's `package.json`:
+
+```json
+{
+  "devDependencies": {
+    "ember-cli-rails-addon": "~> 0.5.0"
+  }
+}
+```
+
 [addon]: https://github.com/rondale-sc/ember-cli-rails-addon/
+[semver]: http://semver.org/
 
 Next, configure Rails to route requests to the `frontend` Ember application:
 
@@ -261,6 +278,12 @@ In order to add that token to your requests, you need to add into your template:
   <% end %>
 <% end %>
 ```
+
+The default `EmberCli::EmberController` and its accompanying view handle this
+for you by default.
+
+However, if you specify your own controller, make sure to append CSRF tags to
+your view's `<head>`.
 
 The [ember-cli-rails-addon][addon] addon will inject an initializer into your
 app to set outgoing requests' `X-CSRF-TOKEN` header to the value injected by

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -3,9 +3,6 @@ require "ember-cli/html_page"
 
 module EmberCli
   class App
-    ADDON_VERSION = "0.0.13"
-    EMBER_CLI_VERSIONS = [ "~> 0.1.5", "~> 0.2.0", "~> 1.13" ]
-
     class BuildError < StandardError; end
 
     attr_reader :name, :options, :paths, :pid
@@ -151,55 +148,10 @@ module EmberCli
 
     def prepare
       @prepared ||= begin
-        check_dependencies!
-        check_addon!
-        check_ember_cli_version!
         reset_build_error!
         symlink_to_assets_root
         add_assets_to_precompile_list
         true
-      end
-    end
-
-    def check_ember_cli_version!
-      version = dev_dependencies.fetch("ember-cli").split(?-).first
-
-      unless Helpers.match_version?(version, EMBER_CLI_VERSIONS)
-        fail <<-MSG.strip_heredoc
-          EmberCLI Rails require ember-cli NPM package version to be
-          #{EMBER_CLI_VERSIONS.last} to work properly (you have #{version}).
-          From within your EmberCLI directory please update your package.json
-          accordingly and run:
-
-            $ npm install
-
-        MSG
-      end
-    end
-
-    def check_addon!
-      unless addon_present?
-        fail <<-MSG.strip_heredoc
-          EmberCLI Rails requires your Ember app to have an addon.
-
-          From within your EmberCLI directory please run:
-
-            $ npm install --save-dev ember-cli-rails-addon@#{ADDON_VERSION}
-
-          in your Ember application root: #{root}
-        MSG
-      end
-    end
-
-    def check_dependencies!
-      unless node_modules_present?
-        fail <<-MSG.strip_heredoc
-          EmberCLI app dependencies are not installed.
-          From your Rails application root please run:
-
-            $ bundle exec rake ember:install
-
-        MSG
       end
     end
 
@@ -266,28 +218,6 @@ module EmberCli
     def package_json
       @package_json ||=
         JSON.parse(paths.package_json_file.read).with_indifferent_access
-    end
-
-    def addon_package_json
-      @addon_package_json ||=
-        JSON.parse(paths.addon_package_json_file.read).with_indifferent_access
-    end
-
-    def addon_version
-      addon_package_json.fetch("version")
-    end
-
-    def dev_dependencies
-      package_json.fetch("devDependencies", {})
-    end
-
-    def addon_present?
-      paths.addon_package_json_file.exist? &&
-        addon_version == ADDON_VERSION
-    end
-
-    def node_modules_present?
-      paths.node_modules.exist?
     end
 
     def excluded_ember_deps

--- a/lib/ember-cli/path_set.rb
+++ b/lib/ember-cli/path_set.rb
@@ -57,16 +57,8 @@ module EmberCli
       root.join("Gemfile")
     end
 
-    define_path :node_modules do
-      root.join("node_modules")
-    end
-
     define_path :package_json_file do
       root.join("package.json")
-    end
-
-    define_path :addon_package_json_file do
-      node_modules.join("ember-cli-rails-addon", "package.json")
     end
 
     define_path :ember do

--- a/spec/lib/ember-cli/path_set_spec.rb
+++ b/spec/lib/ember-cli/path_set_spec.rb
@@ -90,29 +90,12 @@ describe EmberCli::PathSet do
     end
   end
 
-  describe "#node_modules" do
-    it "is a child of #root" do
-      path_set = build_path_set
-
-      expect(path_set.node_modules).to eq path_set.root.join("node_modules")
-    end
-  end
-
   describe "#package_json_file" do
     it "is a child of #root" do
       path_set = build_path_set
 
       expect(path_set.package_json_file)
         .to eq path_set.root.join("package.json")
-    end
-  end
-
-  describe "#addon_package_json_file" do
-    it "is a child of #root" do
-      path_set = build_path_set
-      path = path_set.node_modules.join("ember-cli-rails-addon", "package.json")
-
-      expect(path_set.addon_package_json_file).to eq(path)
     end
   end
 


### PR DESCRIPTION
Closes [#262].

Managing user dependencies within app code is more trouble than it's
worth. Being explicit about our EmberCLI support in our `README.md` and
keeping the addon version in lock-step with the gem will be a better
solution long term.

Since EmberCLI now [writes to STDERR][stderr], which EmberCLI-Rails
[pipes to a file and monitors][error-file], front-end failures will
communicated to users through normal Error-raising means.

[#262]: https://github.com/thoughtbot/ember-cli-rails/issues/262
[stderr]: https://github.com/ember-cli/ember-cli/pull/5039
[error-file]: https://github.com/thoughtbot/ember-cli-rails/pull/245