### PR TITLE
Ensure `bower` executable exists

### DIFF
--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -37,17 +37,7 @@ module EmberCli
 
       exec "#{paths.npm} prune && #{paths.npm} install"
 
-      if paths.bower.nil?
-        fail <<-FAIL
-          Bower is required by EmberCLI
-
-          Install it with:
-
-              $ npm install -g bower
-        FAIL
-      else
-        exec "#{paths.bower} prune && #{paths.bower} install"
-      end
+      exec "#{paths.bower} prune && #{paths.bower} install"
     end
 
     def run

--- a/lib/ember-cli/path_set.rb
+++ b/lib/ember-cli/path_set.rb
@@ -65,8 +65,12 @@ module EmberCli
       root.join("node_modules", ".bin", "ember").tap do |path|
         unless path.executable?
           fail DependencyError.new <<-MSG.strip_heredoc
-            No local ember executable found. You should run `npm install`
-            inside the #{app_name} app located at #{root}
+            No `ember-cli` executable found for `#{app_name}`.
+
+            Install it:
+
+                $ cd #{root}
+                $ npm install
           MSG
         end
       end
@@ -85,7 +89,17 @@ module EmberCli
     end
 
     define_path :bower do
-      app_options.fetch(:bower_path) { configuration.bower_path }
+      app_options.fetch(:bower_path) { configuration.bower_path }.tap do |path|
+        unless Pathname(path).executable?
+          fail DependencyError.new <<-MSG.strip_heredoc
+          Bower is required by EmberCLI
+
+          Install it with:
+
+              $ npm install -g bower
+          MSG
+        end
+      end
     end
 
     define_path :npm do

--- a/spec/lib/ember-cli/path_set_spec.rb
+++ b/spec/lib/ember-cli/path_set_spec.rb
@@ -153,19 +153,21 @@ describe EmberCli::PathSet do
 
   describe "#bower" do
     it "can be overridden" do
-      app = build_app(options: { bower_path: "bower-path" })
+      fake_bower = create_executable(ember_cli_root.join("bower"))
+      app = build_app(options: { bower_path: fake_bower })
 
       path_set = build_path_set(app: app)
 
-      expect(path_set.bower).to eq "bower-path"
+      expect(path_set.bower).to eq fake_bower
     end
 
     it "can be configured" do
-      configuration = double(bower_path: "bower-path")
+      fake_bower = create_executable(ember_cli_root.join("bower"))
+      configuration = double(bower_path: fake_bower)
 
       path_set = build_path_set(configuration: configuration)
 
-      expect(path_set.bower).to eq "bower-path"
+      expect(path_set.bower).to eq fake_bower
     end
   end
 


### PR DESCRIPTION
Move the responsibility of ensuring that a `bower` executable is
available to the `EmberCli::PathSet` class.