### PR TITLE
Introduce `EmberCli::Shell`

### DIFF
--- a/lib/ember-cli/command.rb
+++ b/lib/ember-cli/command.rb
@@ -1,0 +1,63 @@
+module EmberCli
+  class Command
+    def initialize(paths:, options: {})
+      @paths = paths
+      @options = options
+    end
+
+    def test
+      "#{paths.ember} test"
+    end
+
+    def build(watch: false)
+      [
+        "#{paths.ember} build",
+        "#{watch_flag(watch)}",
+        "--environment #{build_environment}",
+        "--output-path #{paths.dist}",
+        pipe_errors_to_file,
+        pipe_to_log_files,
+      ].join(" ")
+    end
+
+    private
+
+    attr_reader :options, :paths
+
+    def process_watcher
+      options.fetch(:watcher) { EmberCli.configuration.watcher }
+    end
+
+    def watch_flag(watch)
+      watch_flag = ""
+
+      if watch
+        watch_flag = "--watch"
+
+        if process_watcher
+          watch_flag += " --watcher #{process_watcher}"
+        end
+      end
+
+      watch_flag
+    end
+
+    def pipe_errors_to_file
+      "2> #{paths.build_error_file}"
+    end
+
+    def pipe_to_log_files
+      if paths.tee
+        "| #{paths.tee} -a #{paths.log}"
+      end
+    end
+
+    def build_environment
+      if EmberCli.env == "production"
+        "production"
+      else
+        "development"
+      end
+    end
+  end
+end

--- a/lib/ember-cli/shell.rb
+++ b/lib/ember-cli/shell.rb
@@ -1,0 +1,82 @@
+require "ember-cli/command"
+
+module EmberCli
+  class Shell
+    def initialize(paths:, env: {}, options: {})
+      @paths = paths
+      @env = env
+      @ember = Command.new(
+        paths: paths,
+        options: options,
+      )
+      @on_exit ||= at_exit { stop }
+    end
+
+    def compile
+      silence_build { exec ember.build }
+    end
+
+    def run
+      lock_buildfile
+      self.pid = spawn ember.build(watch: true)
+      detach
+    end
+
+    def stop
+      if pid.present?
+        Process.kill(:INT, pid)
+        self.pid = nil
+      end
+    end
+
+    def running?
+      pid.present? && Process.getpgid(pid)
+    rescue Errno::ESRCH
+      false
+    end
+
+    def install
+      if paths.gemfile.exist?
+        exec "#{paths.bundler} install"
+      end
+
+      exec "#{paths.npm} prune && #{paths.npm} install"
+      exec "#{paths.bower} prune && #{paths.bower} install"
+    end
+
+    def test
+      exec ember.test
+    end
+
+    private
+
+    attr_accessor :pid
+    attr_reader :ember, :env, :options, :paths
+
+    def spawn(command)
+      exec(command, method: :spawn)
+    end
+
+    def exec(command, method: :system)
+      Dir.chdir paths.root do
+        Kernel.public_send(method, env, command, err: :out) || exit(1)
+      end
+    end
+
+    def lock_buildfile
+      FileUtils.touch(paths.lockfile)
+    end
+
+    def detach
+      Process.detach pid
+    end
+
+    def silence_build(&block)
+      if ENV.fetch("EMBER_CLI_RAILS_VERBOSE") { EmberCli.env.production? }
+        yield
+      else
+        silence_stream(STDOUT, &block)
+      end
+    end
+  end
+end

--- a/spec/lib/ember-cli/command_spec.rb
+++ b/spec/lib/ember-cli/command_spec.rb
@@ -1,0 +1,118 @@
+require "ember-cli/command"
+
+describe EmberCli::Command do
+  describe "#test" do
+    it "builds an `ember test` command" do
+      paths = build_paths(ember: "path/to/ember")
+      command = build_command(paths: paths)
+
+      expect(command.test).to eq("path/to/ember test")
+    end
+  end
+
+  describe "#build" do
+    it "builds an `ember build` command" do
+      paths = build_paths(ember: "path/to/ember")
+      command = build_command(paths: paths)
+
+      expect(command.build).to match(%{path/to/ember build})
+    end
+
+    context "when building in production" do
+      it "includes the `--environment production` flag" do
+        paths = build_paths
+        command = build_command(paths: paths)
+        allow(EmberCli).to receive(:env).and_return("production")
+
+        expect(command.build).to match(/--environment production/)
+      end
+    end
+
+    context "when building in any other environment" do
+      it "includes the `--environment development` flag" do
+        paths = build_paths
+        command = build_command(paths: paths)
+        allow(EmberCli).to receive(:env).and_return("test")
+
+        expect(command.build).to match(/--environment development/)
+      end
+    end
+
+    it "includes the `--output-path` flag" do
+      paths = build_paths(dist: "path/to/dist")
+      command = build_command(paths: paths)
+
+      expect(command.build).to match(%r{--output-path path/to/dist})
+    end
+
+    it "redirects STDERR to the build error file" do
+      paths = build_paths(build_error_file: "path/to/errors.txt")
+      command = build_command(paths: paths)
+
+      expect(command.build).to match(%r{2> path/to/errors\.txt})
+    end
+
+    context "when `tee` command exists" do
+      it "uses `tee` to pipe to log files" do
+        paths = build_paths(tee: "path/to/tee", log: "path/to/logs")
+        command = build_command(paths: paths)
+
+        expect(command.build).to match(%r{| path/to/tee -a path/to/logs})
+      end
+    end
+
+    context "when `tee` command is missing" do
+      it "does not pipe `tee` to log files" do
+        paths = build_paths(tee: nil)
+        command = build_command(paths: paths)
+
+        expect(command.build).not_to match(%r{\|})
+      end
+
+      context "when configured not to watch" do
+        it "excludes the `--watch` flag" do
+          paths = build_paths
+          command = build_command(paths: paths)
+
+          expect(command.build).not_to match(/--watch/)
+        end
+      end
+
+      context "when configured to watch" do
+        it "includes the `--watch` flag" do
+          paths = build_paths
+          command = build_command(paths: paths)
+
+          expect(command.build(watch: true)).to match(/--watch/)
+        end
+
+        it "defaults to configuration for the `--watcher` flag" do
+          paths = build_paths
+          command = build_command(paths: paths)
+          allow(EmberCli).
+            to receive(:configuration).
+            and_return(build_paths(watcher: "bar"))
+
+          expect(command.build(watch: true)).to match(/--watcher bar/)
+        end
+
+        context "when a watcher is configured" do
+          it "configures the build with the value" do
+            paths = build_paths
+            command = build_command(paths: paths, options: { watcher: "foo" })
+
+            expect(command.build(watch: true)).to match(/--watcher foo/)
+          end
+        end
+      end
+    end
+  end
+
+  def build_paths(**options)
+    double(options).as_null_object
+  end
+
+  def build_command(**options)
+    EmberCli::Command.new(options)
+  end
+end


### PR DESCRIPTION
To reduce the complexity of `EmberCli::App`, introduce the
`EmberCli::Shell` class to manage `ember build` system process.

Introduces `EmberCli::Command` to abstract the tedium of building
`ember` commands.