### PR TITLE
Introduce `EmberCli::BuildMonitor`

### DIFF
--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -1,7 +1,8 @@
 require "ember-cli/engine" if defined?(Rails)
 
 module EmberCli
-  class DependencyError < StandardError; end
+  class BuildError < StandardError; end
+  class DependencyError < BuildError; end
 
   extend self
 

--- a/lib/ember-cli/build_monitor.rb
+++ b/lib/ember-cli/build_monitor.rb
@@ -1,0 +1,42 @@
+module EmberCli
+  class BuildMonitor
+    def initialize(name, paths)
+      @name = name
+      @paths = paths
+    end
+
+    def check!
+      if build_error?
+        raise_build_error!
+      end
+    end
+
+    def reset
+      if build_error?
+        error_file.delete
+      end
+    end
+
+    private
+
+    attr_reader :name, :paths
+
+    def build_error?
+      error_file.exist? && error_file.size?
+    end
+
+    def error_file
+      paths.build_error_file
+    end
+
+    def raise_build_error!
+      backtrace = error_file.readlines.reject(&:blank?)
+      message = "#{name.inspect} has failed to build: #{backtrace.first}"
+
+      error = BuildError.new(message)
+      error.set_backtrace(backtrace)
+
+      fail error
+    end
+  end
+end


### PR DESCRIPTION
The `BuildMonitor` class exposes two methods: `#check!` and `#reset`.

The `#check` method inspects the contents of the configured error file,
raising a `BuildError` if it isn't blank.

The `#reset` method will remove the error file when present.

This abstract moves the logic of monitoring for build errors out of
`EmberCli::App`, further simplifying the class and further minimizing
its responsibilities.