### PR TITLE
Introduce `EmberCli::Sprockets`

### DIFF
--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -6,20 +6,14 @@ module EmberRailsHelper
 
     head, body = markup_capturer.capture
 
-    html = EmberCli[name].index_html(
-      sprockets: self,
-      head: head,
-      body: body,
-    )
-
-    render inline: html
+    render inline: EmberCli[name].sprockets.index_html(head: head, body: body)
   end
 
   def include_ember_script_tags(name, **options)
-    javascript_include_tag(*EmberCli[name].exposed_js_assets, options)
+    javascript_include_tag(*EmberCli[name].sprockets.assets, options)
   end
 
   def include_ember_stylesheet_tags(name, **options)
-    stylesheet_link_tag(*EmberCli[name].exposed_css_assets, options)
+    stylesheet_link_tag(*EmberCli[name].sprockets.assets, options)
   end
 end

--- a/lib/ember-cli/sprockets.rb
+++ b/lib/ember-cli/sprockets.rb
@@ -1,0 +1,44 @@
+require "non-stupid-digest-assets"
+require "ember-cli/html_page"
+
+module EmberCli
+  class Sprockets
+    def initialize(app)
+      @app = app
+    end
+
+    def register!
+      assets = %r{\A#{app.name}/}
+
+      Rails.configuration.assets.precompile << assets
+      NonStupidDigestAssets.whitelist << assets
+    end
+
+    def index_html(head:, body:)
+      html_page = HtmlPage.new(
+        content: app.index_file.read,
+        head: head,
+        body: body,
+      )
+
+      html_page.render
+    end
+
+    def assets
+      ["#{app.name}/assets/vendor", "#{app.name}/assets/#{ember_app_name}"]
+    end
+
+    private
+
+    attr_reader :app
+
+    def ember_app_name
+      @ember_app_name ||= app.options.fetch(:name) { package_json.fetch(:name) }
+    end
+
+    def package_json
+      @package_json ||=
+        JSON.parse(app.paths.package_json_file.read).with_indifferent_access
+    end
+  end
+end


### PR DESCRIPTION
Manage integration with Asset Pipeline with `EmberCli::Sprockets`.

This commit moves the focus of the Rails helpers' integration from the
`EmberCli::App` instance to the `EmberCli::Sprockets` instance.

This commit further simplifies and reduces the responsibilities of the
`App` class.