### PR TITLE
Add test coverage for `EmberCli::App#test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Always pass `--environment test` to Rails-generated `ember test` commands.
+  [#277]
 * No longer check dependencies within the app. Defer to EmberCLI's `stderr`
   streaming. [#267]
 * Remove `enable` configuration in favor of using `mount_ember_app`.  [#261]
@@ -15,6 +17,7 @@ master
 * `manifest.json`. Since we now defer to EmberCLI, we no longer need to
   manually resolve asset URLs. [#250]
 
+[#277]: https://github.com/thoughtbot/ember-cli-rails/pull/277
 [#267]: https://github.com/thoughtbot/ember-cli-rails/pull/267
 [#264]: https://github.com/thoughtbot/ember-cli-rails/pull/264
 [#263]: https://github.com/thoughtbot/ember-cli-rails/pull/263

--- a/lib/ember-cli/command.rb
+++ b/lib/ember-cli/command.rb
@@ -6,7 +6,7 @@ module EmberCli
     end
 
     def test
-      "#{paths.ember} test"
+      "#{paths.ember} test --environment test"
     end
 
     def build(watch: false)

--- a/spec/lib/ember-cli/app_spec.rb
+++ b/spec/lib/ember-cli/app_spec.rb
@@ -1,0 +1,9 @@
+require "ember-cli-rails"
+
+describe "User tests Ember app" do
+  it "exits with exit status of 0" do
+    passed = EmberCli["my-app"].test
+
+    expect(passed).to be true
+  end
+end

--- a/spec/lib/ember-cli/command_spec.rb
+++ b/spec/lib/ember-cli/command_spec.rb
@@ -6,7 +6,7 @@ describe EmberCli::Command do
       paths = build_paths(ember: "path/to/ember")
       command = build_command(paths: paths)
 
-      expect(command.test).to eq("path/to/ember test")
+      expect(command.test).to eq("path/to/ember test --environment test")
     end
   end
 


### PR DESCRIPTION
Always pass `--environment test` to `ember test` command from Rails.

Resolve testing issue by adding test coverage.

Required rondale-sc/ember-cli-rails-addon#20 to correct fingerprinting
issue.

[#20]: https://github.com/rondale-sc/ember-cli-rails-addon/pull/20