### PR TITLE
Deprecate `include_ember_index_html` view helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Deprecate `include_ember_index_html` in favor of the renamed
+  `render_ember_app`.
 * Always pass `--environment test` to Rails-generated `ember test` commands.
   [#277]
 * No longer check dependencies within the app. Defer to EmberCLI's `stderr`

--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ Rails.application.routes.draw do
 end
 ```
 
-To serve the EmberCLI generated `index.html`, use the `include_ember_index_html`
+To serve the EmberCLI generated `index.html`, use the `render_ember_app`
 helper in your view:
 
 ```erb
 <!-- app/views/application/index.html.erb -->
-<%= include_ember_index_html :frontend %>
+<%= render_ember_app :frontend %>
 ```
 
 To inject markup into page, pass in a block that accepts the `head`, and
@@ -168,7 +168,7 @@ To inject markup into page, pass in a block that accepts the `head`, and
 
 ```erb
 <!-- app/views/application/index.html.erb -->
-<%= include_ember_index_html :frontend do |head| %>
+<%= render_ember_app :frontend do |head| %>
   <% head.append do %>
     <%= csrf_meta_tags %>
   <% end %>
@@ -272,7 +272,7 @@ In order to add that token to your requests, you need to add into your template:
 
 ```erb
 <!-- app/views/application/index.html.erb -->
-<%= include_ember_index_html :frontend do |head| %>
+<%= render_ember_app :frontend do |head| %>
   <% head.append do %>
     <%= csrf_meta_tags %>
   <% end %>

--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -2,6 +2,16 @@ require "ember-cli/capture"
 
 module EmberRailsHelper
   def include_ember_index_html(name, &block)
+    warn <<-MSG.strip_heredoc
+      The `include_ember_index_html` helper has been deprecated.
+
+      Rename all invocations to `render_ember_app`
+    MSG
+
+    render_ember_app(name, &block)
+  end
+
+  def render_ember_app(name, &block)
     markup_capturer = EmberCli::Capture.new(sprockets: self, &block)
 
     head, body = markup_capturer.capture

--- a/app/views/ember_cli/ember/index.html.erb
+++ b/app/views/ember_cli/ember/index.html.erb
@@ -1,4 +1,4 @@
-<%= include_ember_index_html @app do |head| %>
+<%= render_ember_app @app do |head| %>
   <% head.append do %>
     <%= csrf_meta_tags %>
   <% end %>

--- a/spec/dummy/app/views/pages/include_index.html.erb
+++ b/spec/dummy/app/views/pages/include_index.html.erb
@@ -1,1 +1,1 @@
-<%= include_ember_index_html "my-app" %>
+<%= render_ember_app "my-app" %>

--- a/spec/dummy/app/views/pages/include_index_empty_block.html.erb
+++ b/spec/dummy/app/views/pages/include_index_empty_block.html.erb
@@ -1,3 +1,3 @@
-<%= include_ember_index_html "my-app" do %>
+<%= render_ember_app "my-app" do %>
   <%= csrf_meta_tags %>
 <% end %>

--- a/spec/dummy/app/views/pages/include_index_head_and_body.html.erb
+++ b/spec/dummy/app/views/pages/include_index_head_and_body.html.erb
@@ -1,4 +1,4 @@
-<%= include_ember_index_html "my-app" do |head, body| %>
+<%= render_ember_app "my-app" do |head, body| %>
   <% head.append do %>
     <%= csrf_meta_tags %>
   <% end %>


### PR DESCRIPTION
Rename `include_ember_index_html` Rails view helper to
`render_ember_app`.