### PR TITLE
Don't `compile` from Controller `before_action`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 master
 ------
 
+0.5.1
+-----
+
+* Invoke `EmberCli::App#compile` in `test` environment, spawn `build` process in
+  development, rely on `rake assets:precompile` in `production`-like
+  environments.
+
 0.5.0
 -----
 

--- a/lib/ember-cli/app.rb
+++ b/lib/ember-cli/app.rb
@@ -35,9 +35,9 @@ module EmberCli
     end
 
     def build
-      if EmberCli.env.development?
+      if development?
         build_and_watch
-      else
+      elsif test?
         compile
       end
 
@@ -59,7 +59,7 @@ module EmberCli
     end
 
     def index_file
-      if EmberCli.env.production?
+      if production?
         paths.applications.join("#{name}.html")
       else
         paths.dist.join("index.html")
@@ -67,6 +67,12 @@ module EmberCli
     end
 
     private
+
+    delegate :development?, :production?, :test?, to: :env
+
+    def env
+      EmberCli.env
+    end
 
     def build_and_watch
       prepare
@@ -84,7 +90,7 @@ module EmberCli
     end
 
     def copy_index_html_file
-      if EmberCli.env.production?
+      if production?
         FileUtils.cp(paths.app_assets.join("index.html"), index_file)
       end
     end


### PR DESCRIPTION
No longer invoke `EmberCli::App#compile` from within
`EmberCli::App#build`.

When deploying to production-like environments, `rake assets:precompile`
will invoke `EmberCli::App#compile`.

When serving locally, compilation isn't necessary, as we'll spawn an
`ember build` into a separate process.