### PR TITLE
Don't `prune` in generated Heroku setup script

### DIFF
--- a/lib/generators/ember-cli/heroku/USAGE
+++ b/lib/generators/ember-cli/heroku/USAGE
@@ -3,8 +3,11 @@ Description:
 
     Once the generator is complete, execute the following:
 
-        heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-nodejs
-        heroku config:set NPM_CONFIG_PRODUCTION=false
+        $ heroku buildpacks:clear
+        $ heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-nodejs
+        $ heroku buildpacks:add --index 2 https://github.com/heroku/heroku-buildpack-ruby
+        $ heroku config:set NPM_CONFIG_PRODUCTION=false
+        $ heroku config:unset SKIP_EMBER
 
 Example:
     rails generate ember-cli:heroku

--- a/lib/generators/ember-cli/heroku/templates/bin_heroku_install.erb
+++ b/lib/generators/ember-cli/heroku/templates/bin_heroku_install.erb
@@ -6,8 +6,6 @@ bower="$(pwd)/node_modules/.bin/bower"
 
 for app in <%= app_paths.map { |app_path| %{"#{app_path}"} }.join(" ") -%>; do
   cd $app &&
-    npm prune &&
     npm install &&
-    $bower prune &&
     $bower install
 done


### PR DESCRIPTION
Since [`ember:install` will invoke `{npm,bower} prune`][shell], don't do
it in `bin/heroku_install`.

[shell]: https://github.com/thoughtbot/ember-cli-rails/blob/78e99a91218a2791882dab719e0caab38ec242a7/lib/ember_cli/shell.rb#L39-L40