### PR TITLE
Add `jruby-9000` to testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,12 @@ notifications:
 rvm:
 - 2.2
 - 2.1
+- jruby-9000
 before_install:
-- qmake -version
 - echo '--colour' > ~/.rspec
 - 'echo ''gem: --no-document'' > ~/.gemrc'
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 before_script: bin/setup
-script: xvfb-run -a bin/rspec
+script: bin/rspec
 env:
   global:
     secure: RbWKxwfpzyQ5uv/jYH68/0J3Y9xe7rQbGULsWZT98FxZcVWLoOFlPPITmnmEK32CjQUww8iMz50FRLxFNmXg8prt1KzpzikVdIZLmYg1NFShI8+JOFhJzwCuk/LLybNUmydejR58FJvV9gS8NYqMh5leFkDM3OwLxhWdcE8hDDQ=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 master
 ------
 
+* No longer redirect `STDERR` to `STDOUT` when executing `ember` commands. This
+  fixes some JRuby bugs. [#288]
+* Don't `prune` in generated Heroku setup script. [#286]
+
+[#288]: https://github.com/thoughtbot/ember-cli-rails/pull/288
+[#286]: https://github.com/thoughtbot/ember-cli-rails/pull/286
+
 0.5.2
 -----
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara-webkit", "~> 1.7.0"
+  gem "poltergeist", "~> 1.8.0"
   gem "codeclimate-test-reporter", require: nil
 end

--- a/bin/clean
+++ b/bin/clean
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+rm -rf spec/dummy/my-app

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -55,7 +55,7 @@ module EmberCli
 
     def exec(command, method: :system)
       Dir.chdir paths.root do
-        Kernel.public_send(method, env, command, err: :out) || exit(1)
+        Kernel.public_send(method, env, command) || exit(1)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ ENV["RAILS_ENV"] = "test"
 require "dummy/application"
 
 require "rspec/rails"
+require "capybara/poltergeist"
 
 Dummy::Application.initialize!
 
@@ -26,8 +27,4 @@ RSpec.configure do |config|
   config.order = :random
 end
 
-Capybara::Webkit.configure do |config|
-  config.block_unknown_urls = true
-end
-
-Capybara.javascript_driver = :webkit
+Capybara.javascript_driver = :poltergeist


### PR DESCRIPTION
Closes [#241].

No longer redirects `STDERR` to `STDOUT` via the `STDOUT` file
descriptor (as described in the [`Kernel#spawn`][spawn] documentation).

Related to [jruby/jruby#3038].

Uses `poltergeist` instead of `capybara-webkit`.

Unfortunately, testing for `jruby` support is impossible until
[thoughtbot/capybara-webkit#725][#725] is resolved.

[#241]: #241
[spawn]: http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-spawn
[jruby/jruby#3038]: jruby/jruby#3038
[#725]: thoughtbot/capybara-webkit#725