### PR TITLE
Escape CLI Command Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Escape generated CLI strings. Adds support for paths with spaces.
+
 0.5.3
 -----
 

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties", ">= 3.2", "< 5"
   spec.add_dependency "non-stupid-digest-assets", "~> 1.0.0"
   spec.add_dependency "sprockets", ">= 2.0"
+  spec.add_dependency "cocaine", "~> 0.5.0"
 end

--- a/lib/ember_cli/command.rb
+++ b/lib/ember_cli/command.rb
@@ -1,3 +1,5 @@
+require "cocaine"
+
 module EmberCli
   class Command
     def initialize(paths:, options: {})
@@ -6,50 +8,50 @@ module EmberCli
     end
 
     def test
-      "#{paths.ember} test --environment test"
+      line = Cocaine::CommandLine.new(paths.ember, "test --environment test")
+
+      line.command
     end
 
     def build(watch: false)
       [
-        "#{paths.ember} build",
-        "#{watch_flag(watch)}",
-        "--environment #{build_environment}",
-        "--output-path #{paths.dist}",
-        pipe_errors_to_file,
-        pipe_to_log_files,
-      ].join(" ")
+        build_command(watch: watch),
+        pipe_to_logs_command,
+      ].compact.join(" | ")
     end
 
     private
 
     attr_reader :options, :paths
 
+    def pipe_to_logs_command
+      unless paths.tee.nil?
+        line = Cocaine::CommandLine.new(paths.tee, "-a :log_file")
+
+        line.command(log_file: paths.log)
+      end
+    end
+
+    def build_command(watch: false)
+      line = Cocaine::CommandLine.new(paths.ember, [
+        "build",
+        ("--watch" if watch),
+        ("--watcher :watcher" if process_watcher),
+        "--environment :environment",
+        "--output-path :output_path",
+        "2> :error_file",
+      ].compact.join(" "))
+
+      line.command(
+        environment: build_environment,
+        output_path: paths.dist,
+        watcher: process_watcher,
+        error_file: paths.build_error_file,
+      )
+    end
+
     def process_watcher
       options.fetch(:watcher) { EmberCli.configuration.watcher }
-    end
-
-    def watch_flag(watch)
-      watch_flag = ""
-
-      if watch
-        watch_flag = "--watch"
-
-        if process_watcher
-          watch_flag += " --watcher #{process_watcher}"
-        end
-      end
-
-      watch_flag
-    end
-
-    def pipe_errors_to_file
-      "2> #{paths.build_error_file}"
-    end
-
-    def pipe_to_log_files
-      if paths.tee
-        "| #{paths.tee} -a #{paths.log}"
-      end
     end
 
     def build_environment

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -6,7 +6,7 @@ describe EmberCli::Command do
       paths = build_paths(ember: "path/to/ember")
       command = build_command(paths: paths)
 
-      expect(command.test).to eq("path/to/ember test --environment test")
+      expect(command.test).to eq("path\/to\/ember test --environment test")
     end
   end
 
@@ -15,7 +15,7 @@ describe EmberCli::Command do
       paths = build_paths(ember: "path/to/ember")
       command = build_command(paths: paths)
 
-      expect(command.build).to match(%{path/to/ember build})
+      expect(command.build).to match(%{path\/to\/ember build})
     end
 
     context "when building in production" do
@@ -24,7 +24,7 @@ describe EmberCli::Command do
         command = build_command(paths: paths)
         allow(EmberCli).to receive(:env).and_return("production")
 
-        expect(command.build).to match(/--environment production/)
+        expect(command.build).to match(/--environment 'production'/)
       end
     end
 
@@ -34,7 +34,7 @@ describe EmberCli::Command do
         command = build_command(paths: paths)
         allow(EmberCli).to receive(:env).and_return("test")
 
-        expect(command.build).to match(/--environment development/)
+        expect(command.build).to match(/--environment 'development'/)
       end
     end
 
@@ -42,14 +42,14 @@ describe EmberCli::Command do
       paths = build_paths(dist: "path/to/dist")
       command = build_command(paths: paths)
 
-      expect(command.build).to match(%r{--output-path path/to/dist})
+      expect(command.build).to match(%r{--output-path 'path\/to\/dist'})
     end
 
     it "redirects STDERR to the build error file" do
       paths = build_paths(build_error_file: "path/to/errors.txt")
       command = build_command(paths: paths)
 
-      expect(command.build).to match(%r{2> path/to/errors\.txt})
+      expect(command.build).to match(%r{2> 'path/to/errors\.txt'})
     end
 
     context "when `tee` command exists" do
@@ -57,7 +57,7 @@ describe EmberCli::Command do
         paths = build_paths(tee: "path/to/tee", log: "path/to/logs")
         command = build_command(paths: paths)
 
-        expect(command.build).to match(%r{| path/to/tee -a path/to/logs})
+        expect(command.build).to match(%r{\| path/to/tee -a 'path/to/logs'})
       end
     end
 
@@ -93,7 +93,7 @@ describe EmberCli::Command do
             to receive(:configuration).
             and_return(build_paths(watcher: "bar"))
 
-          expect(command.build(watch: true)).to match(/--watcher bar/)
+          expect(command.build(watch: true)).to match(/--watcher 'bar'/)
         end
 
         context "when a watcher is configured" do
@@ -101,7 +101,7 @@ describe EmberCli::Command do
             paths = build_paths
             command = build_command(paths: paths, options: { watcher: "foo" })
 
-            expect(command.build(watch: true)).to match(/--watcher foo/)
+            expect(command.build(watch: true)).to match(/--watcher 'foo'/)
           end
         end
       end


### PR DESCRIPTION
Closes [#156].

Use `Cocaine` to generate properly escaped CLI commands.

[#156]: https://github.com/thoughtbot/ember-cli-rails/issues/156