### PR TITLE
Ensure `EmberCli::App#root` delegates to `PathSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 master
 ------
 
+* Expose `EmberCli::App#root` for Heroku generator. Fixes [#295]. [#296]
+
+[#295]: https://github.com/thoughtbot/ember-cli-rails/issues/295
+[#296]: https://github.com/thoughtbot/ember-cli-rails/pull/296
+
 0.5.4
 -----
 

--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -24,6 +24,10 @@ module EmberCli
       @build = BuildMonitor.new(name, @paths)
     end
 
+    def root
+      paths.root
+    end
+
     def compile
       @compiled ||= begin
         prepare

--- a/spec/lib/ember_cli/app_spec.rb
+++ b/spec/lib/ember_cli/app_spec.rb
@@ -1,9 +1,25 @@
 require "ember-cli-rails"
 
-describe "User tests Ember app" do
-  it "exits with exit status of 0" do
-    passed = silence_stream(STDOUT) { EmberCli["my-app"].test }
+describe EmberCli::App do
+  describe "#test" do
+    it "exits with exit status of 0" do
+      passed = silence_stream(STDOUT) { EmberCli["my-app"].test }
 
-    expect(passed).to be true
+      expect(passed).to be true
+    end
+  end
+
+  describe "#root" do
+    it "delegates to PathSet" do
+      root_path = Pathname(".")
+      allow_any_instance_of(EmberCli::PathSet).
+        to receive(:root).
+        and_return(root_path)
+      app = EmberCli::App.new("foo")
+
+      root = app.root
+
+      expect(root).to eq root_path
+    end
   end
 end


### PR DESCRIPTION
Closes [#295].

[#295]: https://github.com/thoughtbot/ember-cli-rails/issues/295