### PR TITLE
Remove dependency on `tee` executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
 rvm:
 - 2.2
 - 2.1
-- jruby-9000
+- jruby-9.0.3.0
 before_install:
 - echo '--colour' > ~/.rspec
 - 'echo ''gem: --no-document'' > ~/.gemrc'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 master
 ------
 
+* No longer depend on `tee` executable. Use `Kernel#{spawn,system}` with
+  redirection options. [#299]
+
+[#299]: https://github.com/thoughtbot/ember-cli-rails/pull/299
+
 0.5.5
 -----
 

--- a/lib/ember_cli/command.rb
+++ b/lib/ember_cli/command.rb
@@ -14,25 +14,6 @@ module EmberCli
     end
 
     def build(watch: false)
-      [
-        build_command(watch: watch),
-        pipe_to_logs_command,
-      ].compact.join(" | ")
-    end
-
-    private
-
-    attr_reader :options, :paths
-
-    def pipe_to_logs_command
-      unless paths.tee.nil?
-        line = Cocaine::CommandLine.new(paths.tee, "-a :log_file")
-
-        line.command(log_file: paths.log)
-      end
-    end
-
-    def build_command(watch: false)
       line = Cocaine::CommandLine.new(paths.ember, [
         "build",
         ("--watch" if watch),
@@ -49,6 +30,10 @@ module EmberCli
         error_file: paths.build_error_file,
       )
     end
+
+    private
+
+    attr_reader :options, :paths
 
     def process_watcher
       options.fetch(:watcher) { EmberCli.configuration.watcher }

--- a/lib/ember_cli/configuration.rb
+++ b/lib/ember_cli/configuration.rb
@@ -22,11 +22,6 @@ module EmberCli
       @apps ||= HashWithIndifferentAccess.new
     end
 
-    def tee_path
-      return @tee_path if defined?(@tee_path)
-      @tee_path = Helpers.which("tee")
-    end
-
     def bower_path
       @bower_path ||= Helpers.which("bower")
     end

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -84,10 +84,6 @@ module EmberCli
       tmp.join("error.txt")
     end
 
-    define_path :tee do
-      app_options.fetch(:tee_path) { configuration.tee_path }
-    end
-
     define_path :bower do
       app_options.fetch(:bower_path) { configuration.bower_path }.tap do |path|
         unless Pathname(path).executable?

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -50,13 +50,18 @@ module EmberCli
     attr_reader :ember, :env, :options, :paths
 
     def spawn(command)
-      exec(command, method: :spawn)
+      Kernel.spawn(env, command, process_options) || exit(1)
     end
 
-    def exec(command, method: :system)
-      Dir.chdir paths.root do
-        Kernel.public_send(method, env, command) || exit(1)
-      end
+    def exec(command)
+      Kernel.system(env, command, process_options) || exit(1)
+    end
+
+    def process_options
+      {
+        chdir: paths.root.to_s,
+        out: paths.log.to_s,
+      }
     end
 
     def running?

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -52,57 +52,39 @@ describe EmberCli::Command do
       expect(command.build).to match(%r{2> 'path/to/errors\.txt'})
     end
 
-    context "when `tee` command exists" do
-      it "uses `tee` to pipe to log files" do
-        paths = build_paths(tee: "path/to/tee", log: "path/to/logs")
+    context "when configured not to watch" do
+      it "excludes the `--watch` flag" do
+        paths = build_paths
         command = build_command(paths: paths)
 
-        expect(command.build).to match(%r{\| path/to/tee -a 'path/to/logs'})
+        expect(command.build).not_to match(/--watch/)
       end
     end
 
-    context "when `tee` command is missing" do
-      it "does not pipe `tee` to log files" do
-        paths = build_paths(tee: nil)
+    context "when configured to watch" do
+      it "includes the `--watch` flag" do
+        paths = build_paths
         command = build_command(paths: paths)
 
-        expect(command.build).not_to match(%r{\|})
+        expect(command.build(watch: true)).to match(/--watch/)
       end
 
-      context "when configured not to watch" do
-        it "excludes the `--watch` flag" do
-          paths = build_paths
-          command = build_command(paths: paths)
+      it "defaults to configuration for the `--watcher` flag" do
+        paths = build_paths
+        command = build_command(paths: paths)
+        allow(EmberCli).
+          to receive(:configuration).
+          and_return(build_paths(watcher: "bar"))
 
-          expect(command.build).not_to match(/--watch/)
-        end
+        expect(command.build(watch: true)).to match(/--watcher 'bar'/)
       end
 
-      context "when configured to watch" do
-        it "includes the `--watch` flag" do
+      context "when a watcher is configured" do
+        it "configures the build with the value" do
           paths = build_paths
-          command = build_command(paths: paths)
+          command = build_command(paths: paths, options: { watcher: "foo" })
 
-          expect(command.build(watch: true)).to match(/--watch/)
-        end
-
-        it "defaults to configuration for the `--watcher` flag" do
-          paths = build_paths
-          command = build_command(paths: paths)
-          allow(EmberCli).
-            to receive(:configuration).
-            and_return(build_paths(watcher: "bar"))
-
-          expect(command.build(watch: true)).to match(/--watcher 'bar'/)
-        end
-
-        context "when a watcher is configured" do
-          it "configures the build with the value" do
-            paths = build_paths
-            command = build_command(paths: paths, options: { watcher: "foo" })
-
-            expect(command.build(watch: true)).to match(/--watcher 'foo'/)
-          end
+          expect(command.build(watch: true)).to match(/--watcher 'foo'/)
         end
       end
     end

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -133,24 +133,6 @@ describe EmberCli::PathSet do
     end
   end
 
-  describe "#tee" do
-    it "can be overridden" do
-      app = build_app(options: { tee_path: "tee-path" })
-
-      path_set = build_path_set(app: app)
-
-      expect(path_set.tee).to eq "tee-path"
-    end
-
-    it "can be configured" do
-      configuration = double(tee_path: "tee-path")
-
-      path_set = build_path_set(configuration: configuration)
-
-      expect(path_set.tee).to eq "tee-path"
-    end
-  end
-
   describe "#bower" do
     it "can be overridden" do
       fake_bower = create_executable(ember_cli_root.join("bower"))


### PR DESCRIPTION
Replace with `Kernel.{spawn,system}` [redirection options].

[redirection options]: http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-spawn