### PR TITLE
Use `posix-spawn` instead of `Kernel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Use `POSIX::Spawn::{spawn,system}`.
 * No longer depend on `tee` executable. Use `Kernel#{spawn,system}` with
   redirection options. [#299]
 

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "non-stupid-digest-assets", "~> 1.0.0"
   spec.add_dependency "sprockets", ">= 2.0"
   spec.add_dependency "cocaine", "~> 0.5.0"
+  spec.add_dependency "posix-spawn", "~> 0.3.0"
 end

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -1,3 +1,4 @@
+require "posix/spawn"
 require "ember_cli/command"
 
 module EmberCli
@@ -50,11 +51,11 @@ module EmberCli
     attr_reader :ember, :env, :options, :paths
 
     def spawn(command)
-      Kernel.spawn(env, command, process_options) || exit(1)
+      POSIX::Spawn::spawn(env, command, process_options) || exit(1)
     end
 
     def exec(command)
-      Kernel.system(env, command, process_options) || exit(1)
+      POSIX::Spawn::system(env, command, process_options) || exit(1)
     end
 
     def process_options


### PR DESCRIPTION
The [posix-spawn] gem removes process forking overhead by using special
process spawning interfaces (`posix_spawn()`, `vfork()`, etc.).

> This gem can keep your application's heap from being copied when
> forking command line processes

[posix-spawn]: https://github.com/rtomayko/posix-spawn