### PR TITLE
Delete old compiled apps on boot, instead of on exit.

### DIFF
--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -32,7 +32,7 @@ module EmberCli
   def enable!
     @enabled ||= begin
       Rails.configuration.assets.paths << root.join("assets").to_s
-      at_exit{ cleanup }
+      cleanup
       true
     end
   end
@@ -69,7 +69,11 @@ module EmberCli
   end
 
   def cleanup
-    root.rmtree if root.exist?
+    old_roots.each(&:rmtree)
+  end
+
+  def old_roots
+    Pathname.glob(Rails.root.join("tmp", "ember-cli-*"))
   end
 
   def each_app


### PR DESCRIPTION
This works better with forking multi-process servers. Specifically, Phusion
Passenger with its default configuration would delete the current compiled app
prematurely, yielding 404s.

Closes [#304].

[#304]:
https://github.com/thoughtbot/ember-cli-rails/issues/304