### PR TITLE
Prevent generating git repo for Ember application

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ c.app :frontend, path: "~/projects/my-ember-app"
 * generate a new Ember project:
 
 ```bash
-$ ember new frontend
+$ ember new frontend --skip-git
 ```
 
 **Initializer options**


### PR DESCRIPTION
Following the original documentation, I accidentally created a Git repo for the Ember application inside the existing Git repo for the Rails app.  However, if you specify `--skip-git` when you create the Ember app, this can be avoided.