### PR TITLE
[BUG] Fix `bin/setup`

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -19,6 +19,11 @@ if ! [ -d spec/dummy/my-app ]; then
   bin/setup_ember
 fi
 
+# Only if this isn't CI
+if [ -z "$CI" ]; then
+  bin/appraisal install
+fi
+
 root="$(pwd)"
 
 cd ${root}/spec/dummy/my-app &&
@@ -26,8 +31,3 @@ cd ${root}/spec/dummy/my-app &&
   bower install
 
 cd ${root}/spec/dummy && bundle exec rake ember:install
-
-# Only if this isn't CI
-if [ -z "$CI" ]; then
-  bin/appraisal install
-fi


### PR DESCRIPTION
Previously, `bin/setup` was failing when executing `bin/appraisal`,
since the command was run within the dummy app directory.