### PR TITLE
Silence exec output on success; display on failure

### DIFF
--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -54,7 +54,15 @@ module EmberCli
     end
 
     def exec(command)
-      Kernel.system(env, command, process_options) || exit(1)
+      Kernel.system(env, command, process_options) ||
+        exit_with_debug_info(command)
+    end
+
+    def exit_with_debug_info(command)
+      STDERR.puts "command has failed: #{command}"
+      STDERR.puts "command output:"
+      STDERR.puts File.read(paths.log)
+      exit 1
     end
 
     def process_options

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -13,7 +13,7 @@ module EmberCli
     end
 
     def compile
-      silence_build { exec ember.build }
+      exec ember.build
     end
 
     def build_and_watch
@@ -76,14 +76,6 @@ module EmberCli
 
     def detach
       Process.detach pid
-    end
-
-    def silence_build(&block)
-      if ENV.fetch("EMBER_CLI_RAILS_VERBOSE") { EmberCli.env.production? }
-        yield
-      else
-        silence_stream(STDOUT, &block)
-      end
     end
   end
 end

--- a/spec/lib/ember_cli/shell_spec.rb
+++ b/spec/lib/ember_cli/shell_spec.rb
@@ -1,0 +1,64 @@
+require "ember-cli-rails"
+require "tmpdir"
+
+describe EmberCli::Shell do
+  describe "#compile" do
+    let(:log) { Tempfile.new("log") }
+    let(:paths) { double(root: Dir.tmpdir, log: log.path) }
+
+    subject { described_class.new(paths: paths) }
+
+    before do
+      allow(subject).to \
+        receive_message_chain(:ember, :build).and_return(command)
+    end
+
+    context "when build succeeds" do
+      let(:command) { "echo stdout && echo stderr > /dev/stderr && exit 0" }
+
+      it "silences stdout" do
+        stdout = capture(:stdout) { subject.compile }
+        expect(stdout).to be_blank
+      end
+
+      it "silences stderr" do
+        stderr = capture(:stderr) { subject.compile }
+        expect(stderr).to be_blank
+      end
+
+      it "captures both stderr and stdout to a log" do
+        subject.compile
+        expect(File.read(log)).to eq("stdout\nstderr\n")
+      end
+
+      it "subsequent runs do not append to log" do
+        subject.compile
+        subject.compile
+        expect(File.read(log)).to eq("stdout\nstderr\n")
+      end
+    end
+
+    context "when build fails" do
+      let(:command) { "echo stdout && echo stderr > /dev/stderr && exit 1" }
+
+      it "exits, and outputs captured stdout and stderr to stderr" do
+        stderr = capture(:stderr) do
+          expect(-> { subject.compile }).to raise_exception(SystemExit)
+        end
+        expect(stderr).to eq(<<-OUTPUT.strip_heredoc)
+          command has failed: #{command}
+          command output:
+          stdout
+          stderr
+        OUTPUT
+      end
+
+      it "silences stdout" do
+        stdout = capture(:stdout) do
+          expect(-> { subject.compile }).to raise_exception(SystemExit)
+        end
+        expect(stdout).to be_blank
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,8 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
   config.infer_spec_type_from_file_location!
   config.order = :random
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ require "capybara/poltergeist"
 
 Dummy::Application.initialize!
 
-Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/support/capture_stream.rb
+++ b/spec/support/capture_stream.rb
@@ -1,0 +1,30 @@
+require "monitor"
+
+module Capture
+  def capture(stream)
+    stream_monitor.synchronize do
+      begin
+        stream = stream.to_s
+        captured_stream = Tempfile.new(stream)
+        stream_io = Object.const_get(stream.upcase)
+        origin_stream = stream_io.dup
+        stream_io.reopen(captured_stream)
+
+        yield
+
+        stream_io.rewind
+        return captured_stream.read
+      ensure
+        captured_stream.close
+        captured_stream.unlink
+        stream_io.reopen(origin_stream)
+      end
+    end
+  end
+
+  def stream_monitor
+    @stream_monitor ||= Monitor.new
+  end
+end
+
+RSpec.configure { |c| c.include Capture }


### PR DESCRIPTION
Motivation: For a reason outside the scope of this PR, `rake ember:compile` was silently failing with a 1 exit status... no output at all. Dug through the source to find that `Kernel.system`'s options were set to redirect a output to a log file. Let's show that output when the command fails!

Two changes here, by commit:

1. Turns out `#silence_build` wasn't really doing anything, since we're already redirecting the output in the `Kernel.system` options. However, it will silence my attempts at printing the output failure! It -- along with the `EMBER_CLI_RAILS_VERBOSE` env flag -- was undocumented, and not used anywhere else. The delete key is my favorite key.

2. On failure, have `#exec` print the failing command and its output to STDERR for easier debugging. So yeah, the verbage I've put in there is pretty crappy; you may want to change the exact output.

Again, no tests for this :frowning:,  but `EmberCli::Shell` appears to be mostly untested (only vicariously and minimally via `EmberCli::App`), so ¯\\\_(ツ)\_/¯

WDYT?