### PR TITLE
Improve command failure reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 master
 ------
 
+* Improve command failure reporting. [#324]
 * Use latest EmberCLI-generated asset files. [#316]
 * Delete previous build output on application boot instead of on process exit.
   [#308]
 
+[#324]: https://github.com/thoughtbot/ember-cli-rails/pull/324
 [#316]: https://github.com/thoughtbot/ember-cli-rails/pull/316
 [#308]: https://github.com/thoughtbot/ember-cli-rails/pull/308
 

--- a/lib/ember_cli/runner.rb
+++ b/lib/ember_cli/runner.rb
@@ -1,0 +1,30 @@
+require "open3"
+
+module EmberCli
+  class Runner
+    def initialize(env: {}, out:, err:, options: {})
+      @env = env
+      @out = out
+      @err = err
+      @options = options
+    end
+
+    def run!(command)
+      output, status = Open3.capture2e(@env, command, @options)
+
+      @out.write(output)
+
+      unless status.success?
+        @err.write <<-MSG.strip_heredoc
+          ERROR: Failed command: `#{command}`
+          OUTPUT:
+            #{output}
+        MSG
+
+        exit 1
+      end
+
+      true
+    end
+  end
+end

--- a/spec/lib/ember_cli/runner_spec.rb
+++ b/spec/lib/ember_cli/runner_spec.rb
@@ -1,0 +1,34 @@
+require "ember_cli/runner"
+
+describe EmberCli::Runner do
+  describe "#run!" do
+    context "when the command fails" do
+      it "writes STDERR and STDOUT to `err`" do
+        out = StringIO.new
+        err = StringIO.new
+        runner = EmberCli::Runner.new(err: err, out: out)
+
+        expect { runner.run!("echo 'out'; echo 'err' > /dev/stderr; exit 1") }.
+          to raise_error(SystemExit)
+
+        [err, out].each(&:rewind)
+
+        expect(err.read).to match(/out\nerr/)
+        expect(out.read).to eq("out\nerr\n")
+      end
+    end
+
+    it "executes the command" do
+      out = StringIO.new
+      err = StringIO.new
+      runner = EmberCli::Runner.new(err: err, out: out)
+
+      runner.run!("echo 'out'")
+
+      [err, out].each(&:rewind)
+
+      expect(err.read).to be_empty
+      expect(out.read).to eq("out\n")
+    end
+  end
+end


### PR DESCRIPTION
* Remove `#silence_build` method from `#exec.`
* Tell the user what happened when a command fails.
* Print both the command and error message for easier debugging.
* Capture both STDOUT and STDERR in #exec.

Commands may output important debugging information via either channel.
Use `Open3.capture2e` instead of `Kernel.system`. It appears to be
impossible to capture both `STDERR` and `STDOUT` simultaneously with the
latter.