### PR TITLE
Improve failure reporting for `render_ember_app`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Raise build errors for `render_ember_app` failures. [#325]
+
 0.5.8
 -----
 
@@ -16,6 +18,7 @@ master
 * Delete previous build output on application boot instead of on process exit.
   [#308]
 
+[#325]: https://github.com/thoughtbot/ember-cli-rails/pull/325
 [#324]: https://github.com/thoughtbot/ember-cli-rails/pull/324
 [#316]: https://github.com/thoughtbot/ember-cli-rails/pull/316
 [#308]: https://github.com/thoughtbot/ember-cli-rails/pull/308

--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -12,7 +12,7 @@ module EmberRailsHelper
 
     head, body = markup_capturer.capture
 
-    render inline: EmberCli[name].sprockets.index_html(head: head, body: body)
+    render inline: EmberCli[name].index_html(head: head, body: body)
   end
 
   def include_ember_script_tags(name, **options)

--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -1,4 +1,5 @@
 require "ember_cli/shell"
+require "ember_cli/html_page"
 require "ember_cli/sprockets"
 require "ember_cli/build_monitor"
 
@@ -46,6 +47,24 @@ module EmberCli
       end
 
       @build.wait!
+    end
+
+    def index_html(head:, body:)
+      if index_file.exist?
+        html = HtmlPage.new(
+          head: head,
+          body: body,
+          content: index_file.read,
+        )
+
+        html.render
+      else
+        @build.check!
+
+        raise BuildError.new <<-MSG
+          EmberCLI failed to generate an `index.html` file.
+        MSG
+      end
     end
 
     def install_dependencies

--- a/lib/ember_cli/sprockets.rb
+++ b/lib/ember_cli/sprockets.rb
@@ -1,7 +1,6 @@
 require "sprockets"
 require "ember_cli/errors"
 require "non-stupid-digest-assets"
-require "ember_cli/html_page"
 require "ember_cli/missing_manifest"
 require "ember_cli/assets"
 
@@ -16,16 +15,6 @@ module EmberCli
     def register!
       register_or_raise!(Rails.configuration.assets.precompile)
       register_or_raise!(NonStupidDigestAssets.whitelist)
-    end
-
-    def index_html(head:, body:)
-      html_page = HtmlPage.new(
-        content: app.index_file.read,
-        head: head,
-        body: body,
-      )
-
-      html_page.render
     end
 
     def javascript_assets


### PR DESCRIPTION
Closes [#287].

Raise build errors if EmberCLI-generated `index.html` is missing.

[#287]: https://github.com/thoughtbot/ember-cli-rails/issues/287