### PR TITLE
Change the name of the error file to ember_cli_error.txt

### DIFF
--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -72,7 +72,7 @@ module EmberCli
     end
 
     def build_error_file
-      @build_error_file ||= tmp.join("error.txt")
+      @build_error_file ||= tmp.join("ember_cli_rails_error.txt")
     end
 
     def bower

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -111,7 +111,8 @@ describe EmberCli::PathSet do
     it "is a child of #tmp" do
       path_set = build_path_set
 
-      expect(path_set.build_error_file).to eq path_set.tmp.join("ember_cli_rails_error.txt")
+      filename = "ember_cli_rails_error.txt"
+      expect(path_set.build_error_file).to eq(path_set.tmp.join(filename))
     end
   end
 

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -111,7 +111,7 @@ describe EmberCli::PathSet do
     it "is a child of #tmp" do
       path_set = build_path_set
 
-      expect(path_set.build_error_file).to eq path_set.tmp.join("error.txt")
+      expect(path_set.build_error_file).to eq path_set.tmp.join("ember_cli_rails_error.txt")
     end
   end
 


### PR DESCRIPTION
Ember build command generates its own tmp/error.txt that overwrites ember
cli rails error file and contains less information. 
Fixes: https://github.com/thoughtbot/ember-cli-rails/issues/318
