### PR TITLE
Remove Deprecated Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 master
 ------
 
+* Remove deprecated `include_ember_index_html` helper and deprecated
+  `build_timeout` and `enabled` configurations. [#334]
 * Raise build errors for `render_ember_app` failures. [#325]
 * Remove `before_{action,filter}` in favor of explicit `EmberCli.build(app)`
   call. [#327]
 
+[#334]: https://github.com/thoughtbot/ember-cli-rails/pull/334
 [#327]: https://github.com/thoughtbot/ember-cli-rails/pull/327
 [#325]: https://github.com/thoughtbot/ember-cli-rails/pull/325
 

--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -1,12 +1,6 @@
 require "ember_cli/capture"
 
 module EmberRailsHelper
-  def include_ember_index_html(name, &block)
-    Warnings.warn_include_index_html
-
-    render_ember_app(name, &block)
-  end
-
   def render_ember_app(name, &block)
     markup_capturer = EmberCli::Capture.new(sprockets: self, &block)
 
@@ -28,14 +22,6 @@ module EmberRailsHelper
   end
 
   module Warnings
-    def self.warn_include_index_html
-      warn <<-MSG.strip_heredoc
-        The `include_ember_index_html` helper has been deprecated.
-
-        Rename all invocations to `render_ember_app`
-      MSG
-    end
-
     def self.warn_asset_helper
       if Rails::VERSION::MAJOR < 4
         warn <<-MSG.strip_heredoc

--- a/lib/ember_cli/configuration.rb
+++ b/lib/ember_cli/configuration.rb
@@ -5,14 +5,6 @@ module EmberCli
     include Singleton
 
     def app(name, **options)
-      if options.has_key? :build_timeout
-        deprecate_timeout
-      end
-
-      if options.has_key? :enable
-        deprecate_enable
-      end
-
       app = App.new(name, options)
       app.sprockets.register!
       apps.store(name, app)
@@ -34,34 +26,6 @@ module EmberCli
       @bundler_path ||= Helpers.which("bundler")
     end
 
-    def build_timeout=(*)
-      deprecate_timeout
-    end
-
     attr_accessor :watcher
-
-    private
-
-    def deprecate_enable
-      warn <<-WARN.strip_heredoc
-
-      The `enable` lambda configuration has been removed.
-
-      Please read https://github.com/thoughtbot/ember-cli-rails/pull/261 for
-      details.
-
-      WARN
-    end
-
-    def deprecate_timeout
-      warn <<-WARN.strip_heredoc
-
-      The `build_timeout` configuration has been removed.
-
-      Please read https://github.com/thoughtbot/ember-cli-rails/pull/259 for
-      details.
-
-      WARN
-    end
   end
 end


### PR DESCRIPTION
* Removes deprecated `include_ember_index_html` helper.
* Removes deprecated `build_timeout` and `enabled` configuration values.