### PR TITLE
Rename `EmberCli::Constraint`

### DIFF
--- a/lib/ember_cli/html_constraint.rb
+++ b/lib/ember_cli/html_constraint.rb
@@ -1,5 +1,5 @@
 module EmberCli
-  class Constraint
+  class HtmlConstraint
     def matches?(request)
       matches = request.format.to_s =~ /html/ || -1
 

--- a/lib/ember_cli/route_helpers.rb
+++ b/lib/ember_cli/route_helpers.rb
@@ -1,4 +1,4 @@
-require "ember_cli/constraint"
+require "ember_cli/html_constraint"
 
 module ActionDispatch
   module Routing
@@ -15,7 +15,7 @@ module ActionDispatch
         )
 
         Rails.application.routes.draw do
-          scope constraints: EmberCli::Constraint.new do
+          scope constraints: EmberCli::HtmlConstraint.new do
             get("#{to}(*rest)", routing_options)
           end
         end

--- a/spec/lib/ember_cli/html_constraint_spec.rb
+++ b/spec/lib/ember_cli/html_constraint_spec.rb
@@ -1,10 +1,10 @@
-require "ember_cli/constraint"
+require "ember_cli/html_constraint"
 
-describe EmberCli::Constraint do
+describe EmberCli::HtmlConstraint do
   describe "#matches?" do
     context %{when the format is "html"} do
       it "return true" do
-        constraint = EmberCli::Constraint.new
+        constraint = EmberCli::HtmlConstraint.new
         request = double(format: :html)
 
         expect(constraint.matches?(request)).to be true
@@ -13,7 +13,7 @@ describe EmberCli::Constraint do
 
     context %{when the format isn't "html"} do
       it "return false" do
-        constraint = EmberCli::Constraint.new
+        constraint = EmberCli::HtmlConstraint.new
         request = double(format: :json)
 
         expect(constraint.matches?(request)).to be false
@@ -22,7 +22,7 @@ describe EmberCli::Constraint do
 
     context %"when the format is empty or nil" do
       it "return false" do
-        constraint = EmberCli::Constraint.new
+        constraint = EmberCli::HtmlConstraint.new
         nil_request = double(format: nil)
         empty_request = double(format: "")
 


### PR DESCRIPTION
Rename to `EmberCli::HtmlConstraint` to more clearly communicate the
constraint's intent.