### PR TITLE
Ensure `Rails.root.join("logs")` exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Ensure `Rails.root.join("log")` exists when writing to logs.
 * Remove deprecated `include_ember_index_html` helper and deprecated
   `build_timeout` and `enabled` configurations. [#334]
 * Raise build errors for `render_ember_app` failures. [#325]

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -23,7 +23,7 @@ module EmberCli
     end
 
     def log
-      @log ||= rails_root.join("log", "ember-#{app_name}.#{environment}.log")
+      @log ||= logs.join("ember-#{app_name}.#{environment}.log")
     end
 
     def dist
@@ -108,6 +108,10 @@ module EmberCli
     attr_reader :app, :configuration, :ember_cli_root, :environment, :rails_root
 
     delegate :name, :options, to: :app, prefix: true
+
+    def logs
+      rails_root.join("log").tap(&:mkpath)
+    end
 
     def default_root
       rails_root.join(app_name)

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -31,13 +31,13 @@ describe EmberCli::PathSet do
     end
   end
 
-  describe "#tmp" do
+  describe "#log" do
     it "depends on the environment" do
       app = build_app(name: "foo")
-
       path_set = build_path_set(app: app, environment: "bar")
 
       expect(path_set.log).to eq rails_root.join("log", "ember-foo.bar.log")
+      expect(rails_root.join("log")).to exist
     end
   end
 


### PR DESCRIPTION
Closes [#332].

EmberCLI-Rails will erratically raise errors if `log/` is missing.

[#332]: https://github.com/thoughtbot/ember-cli-rails/issues/332