### PR TITLE
Rename generator namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Rename generator namespace from `ember-cli` to `ember`. [#344]
 * Ensure `Rails.root.join("log")` exists when writing to logs.
 * Remove deprecated `include_ember_index_html` helper and deprecated
   `build_timeout` and `enabled` configurations. [#334]
@@ -8,6 +9,7 @@ master
 * Remove `before_{action,filter}` in favor of explicit `EmberCli.build(app)`
   call. [#327]
 
+[#344]: https://github.com/thoughtbot/ember-cli-rails/pull/344
 [#334]: https://github.com/thoughtbot/ember-cli-rails/pull/334
 [#327]: https://github.com/thoughtbot/ember-cli-rails/pull/327
 [#325]: https://github.com/thoughtbot/ember-cli-rails/pull/325

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ bundle install
 First, generate the gem's initializer:
 
 ```bash
-$ rails generate ember-cli:init
+$ rails generate ember:init
 ```
 
 This will create the following initializer:
@@ -354,9 +354,9 @@ directories %w[app config lib spec your-appname/app]
 
 To configure your Ember CLI Rails app to be ready to deploy on Heroku:
 
-1. Run `rails g ember-cli:heroku` generator
+1. Execute `rails generate ember:heroku`
 1. [Add the NodeJS buildpack][buildpack] and configure NPM to include the
-   `bower` dependency's executable file.
+   `bower` dependency's executable file:
 
 ```sh
 $ heroku buildpacks:clear

--- a/lib/generators/ember-cli/heroku/USAGE
+++ b/lib/generators/ember-cli/heroku/USAGE
@@ -10,7 +10,7 @@ Description:
         $ heroku config:unset SKIP_EMBER
 
 Example:
-    rails generate ember-cli:heroku
+    rails generate ember:heroku
 
     This will install the following gems:
         rails_12factor

--- a/lib/generators/ember-cli/heroku/heroku_generator.rb
+++ b/lib/generators/ember-cli/heroku/heroku_generator.rb
@@ -2,7 +2,7 @@ module EmberCli
   class HerokuGenerator < Rails::Generators::Base
     source_root File.expand_path("../templates", __FILE__)
 
-    namespace "ember-cli:heroku"
+    namespace "ember:heroku"
 
     def copy_package_json_file
       template "package.json.erb", "package.json"

--- a/lib/generators/ember-cli/init/USAGE
+++ b/lib/generators/ember-cli/init/USAGE
@@ -1,8 +1,8 @@
 Description:
-  Generates ember cli initializer.  The initializer sets up where the EmberCli application will live (by default in app/frontend)
+  Generates `ember.rb` initializer.
 
 Example:
-    rails generate ember-cli:init
+    rails generate ember:init
 
     This will create:
         config/initializers/ember.rb

--- a/lib/generators/ember-cli/init/init_generator.rb
+++ b/lib/generators/ember-cli/init/init_generator.rb
@@ -2,7 +2,7 @@ module EmberCli
   class InitGenerator < Rails::Generators::Base
     source_root File.expand_path("../templates", __FILE__)
 
-    namespace "ember-cli:init"
+    namespace "ember:init"
 
     def copy_initializer_file
       copy_file "initializer.rb", "config/initializers/ember.rb"


### PR DESCRIPTION
Make new `rails generate` namespace match the Rake tasks and
`config/initializer/ember.rb`.