### PR TITLE
Invoke `EmberCli[ember_app].build` from helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Invoke `EmberCli[ember_app].build` from helpers to ensure everything is built
+  before serving. [#347]
 * Remove dependency on `sprockets`. Serve generated files with `Rack::File`.
   [#336]
 * Rename generator namespace from `ember-cli` to `ember`. [#344]
@@ -11,6 +13,7 @@ master
 * Remove `before_{action,filter}` in favor of explicit `EmberCli.build(app)`
   call. [#327]
 
+[#347]: https://github.com/thoughtbot/ember-cli-rails/pull/347
 [#336]: https://github.com/thoughtbot/ember-cli-rails/pull/336
 [#344]: https://github.com/thoughtbot/ember-cli-rails/pull/344
 [#334]: https://github.com/thoughtbot/ember-cli-rails/pull/334

--- a/README.md
+++ b/README.md
@@ -222,15 +222,14 @@ Rails.application.routes.draw do
 end
 ```
 
-When serving the EmberCLI generated `index.html`, make sure the controller's
-`layout` is disabled, as EmberCLI generates a fully-formed HTML document:
+When serving the EmberCLI generated `index.html` with the `render_ember_app`
+helper, make sure the controller's `layout` is disabled, as EmberCLI generates a
+fully-formed HTML document:
 
 ```rb
 # app/controllers/application.rb
 class ApplicationController < ActionController::Base
   def index
-    EmberCli.build("my-app")
-
     render layout: false
   end
 end

--- a/app/controller/ember_cli/ember_controller.rb
+++ b/app/controller/ember_cli/ember_controller.rb
@@ -1,8 +1,6 @@
 module EmberCli
   class EmberController < ::ApplicationController
     def index
-      EmberCli.build(ember_app)
-
       render layout: false
     end
 

--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -3,6 +3,8 @@ require "ember_cli/assets"
 
 module EmberRailsHelper
   def render_ember_app(name, &block)
+    EmberCli[name].build
+
     markup_capturer = EmberCli::Capture.new(sprockets: self, &block)
 
     head, body = markup_capturer.capture
@@ -11,6 +13,8 @@ module EmberRailsHelper
   end
 
   def include_ember_script_tags(name, **options)
+    EmberCli[name].build
+
     assets = EmberCli::Assets.new(EmberCli[name])
 
     assets.javascript_assets.
@@ -19,6 +23,8 @@ module EmberRailsHelper
   end
 
   def include_ember_stylesheet_tags(name, **options)
+    EmberCli[name].build
+
     assets = EmberCli::Assets.new(EmberCli[name])
 
     assets.stylesheet_assets.


### PR DESCRIPTION
While the initial invocation can be slow, subsequent calls end up being
no-ops.

This change address a slew of errors and user-filed issues about assets
not being compiled before requests are served.