### PR TITLE
Move `#index_file` to `PathSet`

### DIFF
--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -75,13 +75,13 @@ module EmberCli
       @shell.test
     end
 
-    def index_file
-      paths.dist.join("index.html")
-    end
-
     private
 
     delegate :development?, :test?, to: :env
+
+    def index_file
+      paths.index_file
+    end
 
     def env
       EmberCli.env

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -18,6 +18,10 @@ module EmberCli
       end
     end
 
+    def index_file
+      dist.join("index.html")
+    end
+
     def tmp
       @tmp ||= root.join("tmp").tap(&:mkpath)
     end

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -52,6 +52,17 @@ describe EmberCli::PathSet do
     end
   end
 
+  describe "#index_file" do
+    it "depends on the app name" do
+      app = build_app(name: "foo")
+
+      path_set = build_path_set(app: app)
+
+      expect(path_set.index_file).
+        to eq ember_cli_root.join("apps", "foo", "index.html")
+    end
+  end
+
   describe "#asset_map" do
     it "globs the dist directory for a asset_map.json" do
       app = build_app(name: "foo")


### PR DESCRIPTION
`#index_file` no longer needs knowledge of the Application state or
environment it's running in.