### PR TITLE
Use `tee` to split `STDOUT` to log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Use system-level `tee` to pipe `STDOUT` to both `STDOUT` and the logs. [#351]
 * Invoke `EmberCli[ember_app].build` from helpers to ensure everything is built
   before serving. [#347]
 * Remove dependency on `sprockets`. Serve generated files with `Rack::File`.
@@ -13,6 +14,7 @@ master
 * Remove `before_{action,filter}` in favor of explicit `EmberCli.build(app)`
   call. [#327]
 
+[#351]: https://github.com/thoughtbot/ember-cli-rails/pull/351
 [#347]: https://github.com/thoughtbot/ember-cli-rails/pull/347
 [#336]: https://github.com/thoughtbot/ember-cli-rails/pull/336
 [#344]: https://github.com/thoughtbot/ember-cli-rails/pull/344

--- a/lib/ember_cli/command.rb
+++ b/lib/ember_cli/command.rb
@@ -14,21 +14,7 @@ module EmberCli
     end
 
     def build(watch: false)
-      line = Cocaine::CommandLine.new(paths.ember, [
-        "build",
-        ("--watch" if watch),
-        ("--watcher :watcher" if process_watcher),
-        "--environment :environment",
-        "--output-path :output_path",
-        "2> :error_file",
-      ].compact.join(" "))
-
-      line.command(
-        environment: build_environment,
-        output_path: paths.dist,
-        watcher: process_watcher,
-        error_file: paths.build_error_file,
-      )
+      "#{ember_build(watch: watch)} | #{tee}"
     end
 
     private
@@ -37,6 +23,28 @@ module EmberCli
 
     def process_watcher
       options.fetch(:watcher) { EmberCli.configuration.watcher }
+    end
+
+    def tee
+      Cocaine::CommandLine.
+        new(paths.tee, "-a :log").
+        command(log: paths.log)
+    end
+
+    def ember_build(watch: false)
+      line = Cocaine::CommandLine.new(paths.ember, [
+        "build",
+        ("--watch" if watch),
+        ("--watcher :watcher" if process_watcher),
+        "--environment :environment",
+        "--output-path :output_path",
+      ].compact.join(" "))
+
+      line.command(
+        environment: build_environment,
+        output_path: paths.dist,
+        watcher: process_watcher,
+      )
     end
 
     def build_environment

--- a/lib/ember_cli/configuration.rb
+++ b/lib/ember_cli/configuration.rb
@@ -21,6 +21,10 @@ module EmberCli
       @npm_path ||= Helpers.which("npm")
     end
 
+    def tee_path
+      @tee_path ||= Helpers.which("tee")
+    end
+
     def bundler_path
       @bundler_path ||= Helpers.which("bundler")
     end

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -97,6 +97,10 @@ module EmberCli
       @npm ||= app_options.fetch(:npm_path) { configuration.npm_path }
     end
 
+    def tee
+      @tee ||= app_options.fetch(:tee_path) { configuration.tee_path }
+    end
+
     def bundler
       @bundler ||= app_options.fetch(:bundler_path) do
         configuration.bundler_path

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -51,8 +51,12 @@ module EmberCli
     attr_reader :ember, :env, :options, :paths
 
     def spawn(command)
-      Kernel.spawn(env, command, chdir: paths.root.to_s, out: paths.log.to_s) ||
-        exit(1)
+      Kernel.spawn(
+        env,
+        command,
+        chdir: paths.root.to_s,
+        err: paths.build_error_file.to_s,
+      ) || exit(1)
     end
 
     def exec(command)

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -15,7 +15,14 @@ describe EmberCli::Command do
       paths = build_paths(ember: "path/to/ember")
       command = build_command(paths: paths)
 
-      expect(command.build).to match(%{path\/to\/ember build})
+      expect(command.build).to match(%r{path\/to\/ember build})
+    end
+
+    it "pipes to `tee`" do
+      paths = build_paths(tee: "path/to/tee", log: "path/to/log")
+      command = build_command(paths: paths)
+
+      expect(command.build).to match(%r{\| path/to/tee -a 'path/to/log'})
     end
 
     context "when building in production" do
@@ -43,13 +50,6 @@ describe EmberCli::Command do
       command = build_command(paths: paths)
 
       expect(command.build).to match(%r{--output-path 'path\/to\/dist'})
-    end
-
-    it "redirects STDERR to the build error file" do
-      paths = build_paths(build_error_file: "path/to/errors.txt")
-      command = build_command(paths: paths)
-
-      expect(command.build).to match(%r{2> 'path/to/errors\.txt'})
     end
 
     context "when configured not to watch" do

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -177,6 +177,24 @@ describe EmberCli::PathSet do
     end
   end
 
+  describe "#tee" do
+    it "can be overridden" do
+      app = build_app(options: { tee_path: "tee-path" })
+
+      path_set = build_path_set(app: app)
+
+      expect(path_set.tee).to eq "tee-path"
+    end
+
+    it "can be configured" do
+      configuration = double(tee_path: "tee-path")
+
+      path_set = build_path_set(configuration: configuration)
+
+      expect(path_set.tee).to eq "tee-path"
+    end
+  end
+
   describe "#bundler" do
     it "can be overridden" do
       app = build_app(options: { bundler_path: "bundler-path" })


### PR DESCRIPTION
Closes [#333].

Reintroduce dependency on `tee` executable.

No longer redirect `:stdout` at the Ruby level. Instead, execute shell
command with `| tee -a :log_file`.

No longer redirect `2>` (`STDERR`) at the system level. Instead,
redirect to the error file in the `Process.spawn` call.

[#333]: https://github.com/thoughtbot/ember-cli-rails/issues/333