### PR TITLE
Introduce `mount_ember_assets` routing helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 master
 ------
 
+* Introduce `mount_ember_assets` to serve Ember assets in asset-helper style
+  projects.
+
 0.6.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ In the corresponding view, use the asset helpers:
 
 ### Mounting multiple Ember applications
 
-Rendering Ember applications from routes other than `/` requires additional
+Rendering Ember applications to paths other than `/` requires additional
 configuration.
 
 Consider a scenario where you had Ember applications named `frontend` and
@@ -429,12 +429,25 @@ and `include_ember_stylesheet_tags` helpers to a path other than `"/"`, a
 `<base>` tag must also be injected with a corresponding `href` value:
 
 ```erb
+<base href="/">
 <%= include_ember_script_tags :frontend %>
 <%= include_ember_stylesheet_tags :frontend %>
 
 <base href="/admin_panel/">
 <%= include_ember_script_tags :admin_panel %>
 <%= include_ember_stylesheet_tags :admin_panel %>
+```
+
+If you're using the `include_ember` style helpers with a single-page Ember
+application that defers routing to the Rails application, insert a call to
+`mount_ember_assets` at the bottom of your routes file to serve the
+EmberCLI-generated assets:
+
+```rb
+# config/routes.rb
+Rails.application.routes.draw do
+  mount_ember_assets :frontend, to: "/"
+end
 ```
 
 ## CSRF Tokens

--- a/lib/ember_cli/route_helpers.rb
+++ b/lib/ember_cli/route_helpers.rb
@@ -3,6 +3,12 @@ require "ember_cli/html_constraint"
 module ActionDispatch
   module Routing
     class Mapper
+      def mount_ember_assets(app_name, to: "/")
+        dist_directory = EmberCli[app_name].paths.dist
+
+        mount Rack::File.new(dist_directory.to_s) => to
+      end
+
       def mount_ember_app(app_name, to:, **options)
         routing_options = options.deep_merge(
           defaults: { ember_app: app_name },
@@ -14,14 +20,12 @@ module ActionDispatch
           format: :html,
         )
 
-        dist_directory = EmberCli[app_name].paths.dist
-
         Rails.application.routes.draw do
           scope constraints: EmberCli::HtmlConstraint.new do
             get("#{to}(*rest)", routing_options)
           end
 
-          mount Rack::File.new(dist_directory.to_s) => to
+          mount_ember_assets app_name, to: to
         end
       end
     end


### PR DESCRIPTION
Inspired by [#311].

The `mount_ember_app` helper mounts both a `Rack::File` application that
serves the EmberCLI-generated assets, as well as a catchall route (scoped
to the `to` argument) that redirects all requests to the Ember
application.

For users that have unconventional applications with Ember code embedded
in Rails pages, this is unwanted behavior.

The `mount_ember_assets` only mounts routes to serve the
EmberCLI-generated assets.

[#311]: https://github.com/thoughtbot/ember-cli-rails/issues/311#issuecomment-163739834