### PR TITLE
Introduce `deploy` configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ------
 
+* Introduce the `deploy` configuration option.
 * Translate Rails environments other than `test` or `development` to
   `production`, unless an `EMBER_ENV` is specified. [#366]
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,38 @@ As long as your [CDN is configured to pull from your Rails application][dns-cdn]
 
 [dns-cdn]: https://robots.thoughtbot.com/dns-cdn-origin
 
+### Deployment Strategies
+
+By default, EmberCLI-Rails will serve the `index.html` file that `ember build`
+produces.
+
+If you need to override this behavior (for instance, if you're using
+[`ember-cli-deploy`'s "Lightning Fast Deployment"][lightning] strategy in
+`production`), you can specify the strategy's class in the initializer:
+
+```rb
+EmberCli.configure do |config|
+  config.app :frontend, deploy: { production: EmberCli::Deploy::Redis }
+end
+```
+
+This example configures the `frontend` Ember application to retrieve the
+index's HTML from an [`ember-cli-deploy-redis`][ember-cli-deploy-redis]
+-populated Redis entry using the
+[`ember-cli-rails-deploy-redis`][ember-cli-rails-deploy-redis] gem.
+
+If you're deploying HTML with a custom strategy in `development` or `test`,
+disable EmberCLI-Rails' build step by setting `ENV["SKIP_EMBER"] = true`.
+
+**NOTE:**
+
+Specifying a deployment strategy is only supported for applications that use the
+`mount_ember_app` and `render_ember_app` helpers.
+
+[ember-cli-deploy-redis]: https://github.com/ember-cli-deploy/ember-cli-deploy-redis
+[ember-cli-rails-deploy-redis]: https://github.com/seanpdoyle/ember-cli-rails-deploy-redis
+[lightning]: https://github.com/ember-cli-deploy/ember-cli-deploy-lightning-pack
+
 ### Heroku
 
 To configure your EmberCLI-Rails applications for Heroku:
@@ -491,6 +523,13 @@ EmberCLI runners to clobber each others' work][#94].
 [Puma]: https://github.com/puma/puma
 [Unicorn]: https://rubygems.org/gems/unicorn
 [#94]: https://github.com/thoughtbot/ember-cli-rails/issues/94#issuecomment-77627453
+
+## `SKIP_EMBER`
+
+If set on the environment, `SKIP_EMBER` will configure `ember-cli-rails` to skip
+the build step entirely. This is useful if you're using an alternative
+deployment strategy in the `test` or `development` environment. By default,
+`ember-cli-rails` will skip the build step in `production`-like environments.
 
 ## `EMBER_ENV`
 

--- a/lib/ember_cli/deploy/file.rb
+++ b/lib/ember_cli/deploy/file.rb
@@ -1,0 +1,35 @@
+require "ember_cli/errors"
+
+module EmberCli
+  module Deploy
+    class File
+      def initialize(app)
+        @app = app
+      end
+
+      def index_html
+        if index_file.exist?
+          index_file.read
+        else
+          check_for_error_and_raise!
+        end
+      end
+
+      private
+
+      attr_reader :app
+
+      def check_for_error_and_raise!
+        app.check_for_errors!
+
+        raise BuildError.new <<-MSG
+          EmberCLI failed to generate an `index.html` file.
+        MSG
+      end
+
+      def index_file
+        app.dist_path.join("index.html")
+      end
+    end
+  end
+end

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -19,10 +19,6 @@ module EmberCli
       end
     end
 
-    def index_file
-      dist.join("index.html")
-    end
-
     def tmp
       @tmp ||= root.join("tmp").tap(&:mkpath)
     end

--- a/spec/lib/ember_cli/deploy/file_spec.rb
+++ b/spec/lib/ember_cli/deploy/file_spec.rb
@@ -1,0 +1,34 @@
+require "tmpdir"
+require "ember_cli/deploy/file"
+
+describe EmberCli::Deploy::File do
+  describe "#index_html" do
+    context "when the file is missing" do
+      it "raises a BuildError" do
+        deploy = EmberCli::Deploy::File.new(build_app)
+
+        expect { deploy.index_html }.to raise_error(EmberCli::BuildError)
+      end
+    end
+
+    it "returns the contents of the app's `index_file`" do
+      app = build_app
+      create_index(app.dist_path, "<html></html>")
+      deploy = EmberCli::Deploy::File.new(app)
+
+      index_html = deploy.index_html
+
+      expect(index_html).to eq("<html></html>")
+    end
+  end
+
+  def create_index(directory, contents)
+    directory.join("index.html").write(contents)
+  end
+
+  def build_app
+    tmpdir = Pathname.new(Dir.mktmpdir)
+
+    double(dist_path: tmpdir, check_for_errors!: false)
+  end
+end

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -52,17 +52,6 @@ describe EmberCli::PathSet do
     end
   end
 
-  describe "#index_file" do
-    it "depends on the app name" do
-      app = build_app(name: "foo")
-
-      path_set = build_path_set(app: app)
-
-      expect(path_set.index_file).
-        to eq ember_cli_root.join("apps", "foo", "index.html")
-    end
-  end
-
   describe "#gemfile" do
     it "is a child of #root" do
       app = build_app(name: "foo")


### PR DESCRIPTION
Extend `ember-cli-rails` to allow for use of 3rd party strategies to
retrieve the HTML to be served by the `mount_ember_app` and
`render_ember_app` helpers.


The `File` deploy strategy, although internal to the gem, depends on the
public API for `EmberCli::App`.