### PR TITLE
Improve README's EmberCLI version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ EmberCLI-Rails is designed to give you the best of both worlds:
 
 If you're having trouble, checkout the [example project]!
 
-**EmberCLI-Rails Supports EmberCLI 1.13.x and later.**
+**EmberCLI-Rails Supports EmberCLI 1.13.13 and later.**
 
 [example project]: https://github.com/seanpdoyle/ember-cli-rails-heroku-example
 
@@ -517,6 +517,12 @@ if (environment === 'development') {
 `RAILS_ENV` will be absent in production builds.
 
 [ember-cli-mirage]: http://ember-cli-mirage.com/docs/latest/
+
+## EmberCLI support
+
+This project supports:
+
+* EmberCLI versions `>= 1.13.13`
 
 ## Ruby and Rails support
 


### PR DESCRIPTION
* Depends on `outputReady` hook introduced in [1.13.9][outputReady]
* Depends on writing errors to `STDERR` introduced in [1.13.9][stderr]

[outputReady]: https://github.com/ember-cli/ember-cli/commit/8c93854ae8b9222aff5406c7211d935ceb49c6d6
[stderr]: https://github.com/ember-cli/ember-cli/commit/9cc1e06fa6bc90825ba7be7cc8df3e569cd492a4