### PR TITLE
Remove Sprockets Configuration from Dummy app

### DIFF
--- a/spec/dummy/application.rb
+++ b/spec/dummy/application.rb
@@ -2,7 +2,6 @@ require "rails"
 
 require "action_controller/railtie"
 require "action_view/railtie"
-require "sprockets/railtie"
 
 Bundler.require(*Rails.groups)
 
@@ -23,11 +22,6 @@ module Dummy
 
     # Print deprecation notices to the stderr.
     config.active_support.deprecation = :stderr
-
-    config.assets.enabled = true
-    config.assets.digest = true
-    config.assets.raise_runtime_errors = true
-    config.assets.version = "1.0"
 
     config.secret_token = "SECRET_TOKEN_IS_MIN_30_CHARS_LONG"
     config.secret_key_base = "SECRET_KEY_BASE"


### PR DESCRIPTION
Since we no longer depend on Sprockets and the Asset Pipeline, `asset`
configuration is no longer necessary, and only adds noise to the
configuration.