### PR TITLE
Prefer `require` over `autoload`

### DIFF
--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -1,15 +1,12 @@
 require "fileutils"
-require "ember_cli/engine"
 require "ember-cli-rails-assets"
+require "ember_cli/engine"
+require "ember_cli/configuration"
+require "ember_cli/helpers"
 require "ember_cli/errors"
 
 module EmberCli
   extend self
-
-  autoload :App,           "ember_cli/app"
-  autoload :Configuration, "ember_cli/configuration"
-  autoload :Helpers,       "ember_cli/helpers"
-  autoload :PathSet,       "ember_cli/path_set"
 
   def configure
     yield configuration

--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -1,5 +1,6 @@
-require "ember_cli/shell"
 require "html_page/renderer"
+require "ember_cli/path_set"
+require "ember_cli/shell"
 require "ember_cli/build_monitor"
 
 module EmberCli

--- a/lib/ember_cli/configuration.rb
+++ b/lib/ember_cli/configuration.rb
@@ -1,4 +1,5 @@
 require "singleton"
+require "ember_cli/app"
 
 module EmberCli
   class Configuration


### PR DESCRIPTION
For the sake of being explicit about dependencies, replace `autoload`
calls with `require` statements.