### PR TITLE
Treat non `{test,development}` envs as `production`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 master
 ------
 
+* Translate Rails environments other than `test` or `development` to
+  `production`, unless an `EMBER_ENV` is specified. [#366]
+
+[#366]: https://github.com/thoughtbot/ember-cli-rails/pull/366
+
 0.6.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ EmberCLI runners to clobber each others' work][#94].
 [Unicorn]: https://rubygems.org/gems/unicorn
 [#94]: https://github.com/thoughtbot/ember-cli-rails/issues/94#issuecomment-77627453
 
+## `EMBER_ENV`
+
+If set on the environment, the value of `EMBER_ENV` will be passed to the
+`ember` process as the value of the `--environment` flag.
+
+If `EMBER_ENV` is unspecified, the current Rails environment will be passed to
+the `ember` process, with the exception of non-standard Rails environments,
+which will be replaced with `production`.
+
 ## `RAILS_ENV`
 
 While being managed by EmberCLI Rails, EmberCLI process will have

--- a/lib/ember-cli-rails.rb
+++ b/lib/ember-cli-rails.rb
@@ -50,7 +50,7 @@ module EmberCli
   end
 
   def env
-    @env ||= Helpers.current_environment.inquiry
+    @env ||= Helpers.current_environment
   end
 
   delegate :apps, to: :configuration

--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -82,7 +82,13 @@ module EmberCli
 
     private
 
-    delegate :development?, :test?, to: :env
+    def development?
+      env.to_s == "development"
+    end
+
+    def test?
+      env.to_s == "test"
+    end
 
     def index_file
       paths.index_file

--- a/lib/ember_cli/helpers.rb
+++ b/lib/ember_cli/helpers.rb
@@ -16,26 +16,16 @@ module EmberCli
     end
 
     def current_environment
-      rails_config_for(:ember_cli_rails_mode){ default_environment }.to_s
+      ENV.fetch("EMBER_ENV") { default_environment }
     end
 
     private
 
     def default_environment
-      if Rails.env.test?
-        "test"
-      elsif Rails.env.production? || !rails_config_for(:consider_all_requests_local)
+      if Rails.env.match(/test|development/)
+        Rails.env
+      else
         "production"
-      else
-        "development"
-      end
-    end
-
-    def rails_config_for(key)
-      if Rails.configuration.respond_to?(key)
-        Rails.configuration.public_send(key)
-      else
-        yield
       end
     end
   end

--- a/spec/lib/ember_cli/helpers_spec.rb
+++ b/spec/lib/ember_cli/helpers_spec.rb
@@ -1,0 +1,58 @@
+require "ember_cli/helpers"
+
+describe EmberCli::Helpers do
+  describe ".current_environment" do
+    context "when EMBER_ENV is set" do
+      it "returns the value of EMBER_ENV" do
+        stub_env("EMBER_ENV" => "staging")
+
+        current_environment = EmberCli::Helpers.current_environment
+
+        expect(current_environment).to eq "staging"
+      end
+    end
+
+    context "when test" do
+      it "returns test" do
+        stub_rails_env("test")
+
+        current_environment = EmberCli::Helpers.current_environment
+
+        expect(current_environment).to eq "test"
+      end
+    end
+
+    context "when development" do
+      it "returns development" do
+        stub_rails_env("development")
+
+        current_environment = EmberCli::Helpers.current_environment
+
+        expect(current_environment).to eq "development"
+      end
+    end
+
+    context "when anything else" do
+      it "returns production" do
+        stub_rails_env("staging")
+
+        current_environment = EmberCli::Helpers.current_environment
+
+        expect(current_environment).to eq "production"
+      end
+    end
+  end
+
+  def stub_env(key_to_value)
+    allow(ENV).
+      to receive(:fetch).
+      with(key_to_value.keys.first).
+      and_return(key_to_value.values.first)
+  end
+
+  def stub_rails_env(env)
+    allow(Rails).
+      to receive(:env).
+      and_return(env.to_s)
+  end
+end


### PR DESCRIPTION
Closes [#361].

When the Rails environment is neither `test` nor `development` ([two
environments handled by EmberCLI out-of-the-box][ember-cli-env]), treat
it as `production`, unless an `EMBER_ENV` is specified.

[#361]: https://github.com/thoughtbot/ember-cli-rails/issues/361
[ember-cli-env]: http://ember-cli.com/user-guide/#Environments