### PR TITLE
Replace character-literal declarations with string

### DIFF
--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -104,7 +104,7 @@ module EmberCli
     end
 
     def excluded_ember_deps
-      Array.wrap(options[:exclude_ember_deps]).join(?,)
+      Array.wrap(options[:exclude_ember_deps]).join("?")
     end
 
     def env_hash

--- a/lib/ember_cli/helpers.rb
+++ b/lib/ember_cli/helpers.rb
@@ -3,7 +3,7 @@ module EmberCli
     extend self
 
     def which(cmd)
-      exts = ENV.fetch("PATHEXT", ?;).split(?;, -1).uniq
+      exts = ENV.fetch("PATHEXT", ";").split(";", -1).uniq
 
       ENV.fetch("PATH").split(File::PATH_SEPARATOR).each do |path|
         exts.each do |ext|


### PR DESCRIPTION
http://stackoverflow.com/a/16641934

Using `?;` instead of `";"` obscures intent and isn't doing us any
favors in terms of performance, since the literal is represented as a
string.

This commit removes all occurrences.