### PR TITLE
Move executable path logic to `PathSet`

### DIFF
--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -12,7 +12,6 @@ module EmberCli
       @options = options
       @paths = PathSet.new(
         app: self,
-        configuration: EmberCli.configuration,
         environment: Rails.env,
         rails_root: Rails.root,
         ember_cli_root: EmberCli.root,

--- a/lib/ember_cli/configuration.rb
+++ b/lib/ember_cli/configuration.rb
@@ -5,6 +5,8 @@ module EmberCli
   class Configuration
     include Singleton
 
+    attr_accessor :watcher
+
     def app(name, **options)
       app = App.new(name, options)
       apps.store(name, app)
@@ -13,23 +15,5 @@ module EmberCli
     def apps
       @apps ||= HashWithIndifferentAccess.new
     end
-
-    def bower_path
-      @bower_path ||= Helpers.which("bower")
-    end
-
-    def npm_path
-      @npm_path ||= Helpers.which("npm")
-    end
-
-    def tee_path
-      @tee_path ||= Helpers.which("tee")
-    end
-
-    def bundler_path
-      @bundler_path ||= Helpers.which("bundler")
-    end
-
-    attr_accessor :watcher
   end
 end

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -1,8 +1,9 @@
+require "ember_cli/helpers"
+
 module EmberCli
   class PathSet
-    def initialize(app:, rails_root:, ember_cli_root:, environment:, configuration:)
+    def initialize(app:, rails_root:, ember_cli_root:, environment:)
       @app = app
-      @configuration = configuration
       @rails_root = rails_root
       @environment = environment
       @ember_cli_root = ember_cli_root
@@ -65,7 +66,7 @@ module EmberCli
 
     def bower
       @bower ||= begin
-        bower_path = app_options.fetch(:bower_path) { configuration.bower_path }
+        bower_path = app_options.fetch(:bower_path) { which("bower") }
 
         bower_path.tap do |path|
           unless Pathname(path).executable?
@@ -82,24 +83,32 @@ module EmberCli
     end
 
     def npm
-      @npm ||= app_options.fetch(:npm_path) { configuration.npm_path }
+      @npm ||= app_options.fetch(:npm_path) { which("npm") }
     end
 
     def tee
-      @tee ||= app_options.fetch(:tee_path) { configuration.tee_path }
+      @tee ||= app_options.fetch(:tee_path) { which("tee") }
     end
 
     def bundler
-      @bundler ||= app_options.fetch(:bundler_path) do
-        configuration.bundler_path
-      end
+      @bundler ||= app_options.fetch(:bundler_path) { which("bundler") }
     end
 
     private
 
-    attr_reader :app, :configuration, :ember_cli_root, :environment, :rails_root
+    attr_reader :app, :ember_cli_root, :environment, :rails_root
 
-    delegate :name, :options, to: :app, prefix: true
+    def app_name
+      app.name
+    end
+
+    def app_options
+      app.options
+    end
+
+    def which(executable)
+      Helpers.which(executable)
+    end
 
     def logs
       rails_root.join("log").tap(&:mkpath)

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -117,11 +117,11 @@ describe EmberCli::PathSet do
       expect(path_set.bower).to eq fake_bower
     end
 
-    it "can be configured" do
+    it "can be inferred from the $PATH" do
       fake_bower = create_executable(ember_cli_root.join("bower"))
-      configuration = double(bower_path: fake_bower)
+      stub_which(bower: fake_bower)
 
-      path_set = build_path_set(configuration: configuration)
+      path_set = build_path_set
 
       expect(path_set.bower).to eq fake_bower
     end
@@ -136,10 +136,10 @@ describe EmberCli::PathSet do
       expect(path_set.npm).to eq "npm-path"
     end
 
-    it "can be configured" do
-      configuration = double(npm_path: "npm-path")
+    it "can be inferred from the $PATH" do
+      stub_which(npm: "npm-path")
 
-      path_set = build_path_set(configuration: configuration)
+      path_set = build_path_set
 
       expect(path_set.npm).to eq "npm-path"
     end
@@ -154,10 +154,10 @@ describe EmberCli::PathSet do
       expect(path_set.tee).to eq "tee-path"
     end
 
-    it "can be configured" do
-      configuration = double(tee_path: "tee-path")
+    it "can be inferred from the $PATH" do
+      stub_which(tee: "tee-path")
 
-      path_set = build_path_set(configuration: configuration)
+      path_set = build_path_set
 
       expect(path_set.tee).to eq "tee-path"
     end
@@ -172,10 +172,10 @@ describe EmberCli::PathSet do
       expect(path_set.bundler).to eq "bundler-path"
     end
 
-    it "can be configured" do
-      configuration = double(bundler_path: "bundler-path")
+    it "can be inferred from the $PATH" do
+      stub_which(bundler: "bundler-path")
 
-      path_set = build_path_set(configuration: configuration)
+      path_set = build_path_set
 
       expect(path_set.bundler).to eq "bundler-path"
     end
@@ -202,11 +202,17 @@ describe EmberCli::PathSet do
     )
   end
 
+  def stub_which(program_to_path)
+    allow(EmberCli::Helpers).
+      to receive(:which).
+      with(program_to_path.keys.first.to_s).
+      and_return(program_to_path.values.last)
+  end
+
   def build_path_set(**options)
     EmberCli::PathSet.new(
       options.reverse_merge(
         app: build_app,
-        configuration: nil,
         rails_root: rails_root,
         ember_cli_root: ember_cli_root,
         environment: "test",


### PR DESCRIPTION
Originally, `EmberCli::Configuration` housed the logic for determining
where `npm`, `bower`, `bundler`, etc were located.

This logic falls under the responsibility of the `PathSet` class.

This commit simplifies the `Configuration` class, and removes
`PathSet`'s dependency on `Configuration`.