### PR TITLE
Fixed heroku generator when deploying project with multiple apps

### DIFF
--- a/lib/generators/ember/heroku/templates/bin_heroku_install.erb
+++ b/lib/generators/ember/heroku/templates/bin_heroku_install.erb
@@ -3,11 +3,10 @@
 set -e
 
 bower="$(pwd)/node_modules/.bin/bower"
-project_root="$(pwd)"
 
 for app in <%= app_paths.map { |app_path| %{"#{app_path}"} }.join(" ") -%>; do
   cd $app &&
     npm install &&
-    $bower install &&
-    cd $project_root
+    $bower install
+  cd -
 done

--- a/lib/generators/ember/heroku/templates/bin_heroku_install.erb
+++ b/lib/generators/ember/heroku/templates/bin_heroku_install.erb
@@ -3,9 +3,11 @@
 set -e
 
 bower="$(pwd)/node_modules/.bin/bower"
+project_root="$(pwd)"
 
 for app in <%= app_paths.map { |app_path| %{"#{app_path}"} }.join(" ") -%>; do
   cd $app &&
     npm install &&
-    $bower install
+    $bower install &&
+    cd $project_root
 done


### PR DESCRIPTION
The current heroku_install bin wasn't able to deploy multiple apps at the same time.
The cd inside the loop was working for the first app since we were inside the project root but the second one was failing because it was trying to cd from the directory of the first app.