### PR TITLE
Don't mount routes to top-level context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ master
 ------
 
 * Fix bug with generated `bin/heroku_install` script iterating through multiple
-  Ember application's directories.
+* Don't mount route helpers at top-level. Instead, mount within the surrounding
+  context with which they're invoked. [#381]
+
+[#381]: https://github.com/thoughtbot/ember-cli-rails/pull/381
 
 0.7.0
 -----

--- a/lib/ember_cli/route_helpers.rb
+++ b/lib/ember_cli/route_helpers.rb
@@ -14,15 +14,13 @@ module ActionDispatch
           format: :html,
         )
 
-        Rails.application.routes.draw do
-          scope constraints: EmberCli::HtmlConstraint.new do
-            get("#{to}(*rest)", routing_options)
-          end
-
-          dist_directory = EmberCli[app_name].paths.dist
-
-          mount Rack::File.new(dist_directory.to_s) => to
+        scope constraints: ::EmberCli::HtmlConstraint.new do
+          get("#{to}(*rest)", routing_options)
         end
+
+        dist_directory = ::EmberCli[app_name].paths.dist
+
+        mount Rack::File.new(dist_directory.to_s) => to
       end
     end
   end


### PR DESCRIPTION
Don't mount route helpers at top-level.

For instance, while serving an Ember application from `/admin/editor`,
the application could be mounted like this:

```rb
mount_ember_app :admin, to: "/admin/editor"
```

The previous implementation allows for this, as it was written with this
use case in mind.

Alternatively, the application could be mounted from within a
`namespace`, `scope`, or `constraint` block. Unfortunately, the previous
implementation doesn't support these use cases, since the routes are
mounted at the global level (i.e. in the first line of a
 `Rails.application.routes.draw` block).

This commit adds support for the latter case, taking into account the
surrounding context with which the route helpers are invoked.