### PR TITLE
Enable `ruby@2.3.x` on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundler
 notifications:
   email: false
 rvm:
+- 2.3.0
 - 2.2
 - 2.1
 - jruby-9.0.3.0


### PR DESCRIPTION
[Ruby 2.3.0 has been released][release].

This commit adds the version to the CI test matrix.

[release]: https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/