### PR TITLE
Introduce `App#mountable?` and `App#to_rack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Introduce the idea of `App#mountable?` and `App#to_rack` for handling deploys
+  that don't serve assets from the file system (Redis, for example).
 * Fix bug with generated `bin/heroku_install` script iterating through multiple
 * Don't mount route helpers at top-level. Instead, mount within the surrounding
   context with which they're invoked. [#381]

--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -78,6 +78,14 @@ module EmberCli
       @build.check!
     end
 
+    def mountable?
+      deploy.mountable?
+    end
+
+    def to_rack
+      deploy.to_rack
+    end
+
     private
 
     def development?

--- a/lib/ember_cli/deploy/file.rb
+++ b/lib/ember_cli/deploy/file.rb
@@ -1,3 +1,4 @@
+require "rack"
 require "ember_cli/errors"
 
 module EmberCli
@@ -5,6 +6,14 @@ module EmberCli
     class File
       def initialize(app)
         @app = app
+      end
+
+      def mountable?
+        true
+      end
+
+      def to_rack
+        Rack::File.new(app.dist_path.to_s)
       end
 
       def index_html

--- a/lib/ember_cli/route_helpers.rb
+++ b/lib/ember_cli/route_helpers.rb
@@ -18,9 +18,15 @@ module ActionDispatch
           get("#{to}(*rest)", routing_options)
         end
 
-        dist_directory = ::EmberCli[app_name].paths.dist
+        mount_ember_assets(app_name, to: to)
+      end
 
-        mount Rack::File.new(dist_directory.to_s) => to
+      def mount_ember_assets(app_name, to: "/")
+        app = ::EmberCli[app_name]
+
+        if app.mountable?
+          mount app.to_rack => to
+        end
       end
     end
   end

--- a/spec/lib/ember_cli/app_spec.rb
+++ b/spec/lib/ember_cli/app_spec.rb
@@ -1,6 +1,30 @@
 require "ember-cli-rails"
 
 describe EmberCli::App do
+  describe "#to_rack" do
+    it "delegates to `#deploy`" do
+      deploy = double(to_rack: :delegated)
+      app = EmberCli["my-app"]
+      allow(app).to receive(:deploy).and_return(deploy)
+
+      to_rack = app.to_rack
+
+      expect(to_rack).to be :delegated
+    end
+  end
+
+  describe "#mountable?" do
+    it "delegates to `#deploy`" do
+      deploy = double(mountable?: :delegated)
+      app = EmberCli["my-app"]
+      allow(app).to receive(:deploy).and_return(deploy)
+
+      mountable = app.mountable?
+
+      expect(mountable).to be :delegated
+    end
+  end
+
   describe "#compile" do
     it "exits with exit status of 0" do
       passed = EmberCli["my-app"].compile

--- a/spec/lib/ember_cli/deploy/file_spec.rb
+++ b/spec/lib/ember_cli/deploy/file_spec.rb
@@ -22,6 +22,26 @@ describe EmberCli::Deploy::File do
     end
   end
 
+  describe "#mountable?" do
+    it "returns true" do
+      deploy = EmberCli::Deploy::File.new(build_app)
+
+      mountable = deploy.mountable?
+
+      expect(mountable).to be true
+    end
+  end
+
+  describe "#to_rack" do
+    it "creates a Rack::File instance" do
+      deploy = EmberCli::Deploy::File.new(build_app)
+
+      rack_app = deploy.to_rack
+
+      expect(rack_app).to respond_to(:call)
+    end
+  end
+
   def create_index(directory, contents)
     directory.join("index.html").write(contents)
   end


### PR DESCRIPTION
For deploys that need to be mounted to be useful, [`File`][file] for
example, this commit exposes an API for encapsulating that logic.
`App#to_rack` will create an instance of a `Rack` application that can
be mounted via `mount $RACK_APP => "/path"`.

For deploys that don't serve assets from the file system,
[`Redis`][redis] for example, `mountable?` should return `false`.

[file]: https://github.com/thoughtbot/ember-cli-rails/blob/v0.7.0/lib/ember_cli/deploy/file.rb
[redis]: https://github.com/seanpdoyle/ember-cli-rails-deploy-redis