### PR TITLE
Move dependencies from Gemfiles to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,7 @@ gemspec
 
 gem "appraisal"
 gem "rails", "4.2.4"
-gem "pry"
-
-group :development, :test do
-  gem "high_voltage", "~> 2.4.0"
-  gem "rspec-rails", "~> 3.3.0"
-end
 
 group :test do
-  gem "poltergeist", "~> 1.8.0"
   gem "codeclimate-test-reporter", require: nil
 end

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -19,4 +19,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties", ">= 3.2", "< 5"
   spec.add_dependency "cocaine", "~> 0.5.8"
   spec.add_dependency "html_page", "~> 0.1.0"
+
+  spec.add_development_dependency "rspec-rails", "~> 3.3.0"
+  spec.add_development_dependency "high_voltage", "~> 2.4.0"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "poltergeist", "~> 1.8.0"
 end

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -7,13 +7,7 @@ gem "test-unit", "~> 3.0"
 gem "rails", :git => "https://github.com/rails/rails.git", :branch => "3-2-stable"
 gem "pry"
 
-group :development, :test do
-  gem "high_voltage", "~> 2.4.0"
-  gem "rspec-rails", "~> 3.3.0"
-end
-
 group :test do
-  gem "poltergeist", "~> 1.8.0"
   gem "codeclimate-test-reporter", :require => nil
 end
 

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -6,13 +6,7 @@ gem "appraisal"
 gem "rails", "~> 4.1.1"
 gem "pry"
 
-group :development, :test do
-  gem "high_voltage", "~> 2.4.0"
-  gem "rspec-rails", "~> 3.3.0"
-end
-
 group :test do
-  gem "poltergeist", "~> 1.8.0"
   gem "codeclimate-test-reporter", :require => nil
 end
 

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -6,14 +6,8 @@ gem "appraisal"
 gem "rails", "~> 4.2.1"
 gem "pry"
 
-group :development, :test do
-  gem "high_voltage", "~> 2.4.0"
-  gem "rspec-rails", "~> 3.3.0"
-end
-
 group :test do
   gem "poltergeist", "~> 1.8.0"
-  gem "codeclimate-test-reporter", :require => nil
 end
 
 gemspec :path => "../"


### PR DESCRIPTION
When adding new dependencies, adding to a single gemspec as a
development dependency is DRYer than adding them to each file in
`gemfiles/*`.
