### PR TITLE
docs: before-filters by subclassing EmberController #373

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,21 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+#### Adding before-filters
+
+To simply add before-filters to the default controller, you can subclass the `EmberCli::EmberController`. This alone won't secure your system, but gives a quick way to hook up things like rollout, flipper, or authentication checks if you need to.
+
+```rb
+# routes, assuming authentication already set up
+mount_ember_app :admin_panel, to: "/admin", controller: 'admin_frontend'
+
+# app/controllers/authenticated_controller.rb
+class AdminFrontendController < EmberCli::EmberController
+  before_action :authenticate_admin_user!
+end
+```
+
+
 ### Rendering the EmberCLI generated JS and CSS
 
 Rendering EmberCLI applications with `render_ember_app` is the recommended,


### PR DESCRIPTION
Following on from #373 this adds a quick way to plug in before-filters to the readme.

Example use cases:
- Analytics: hit mixpanel on download, including user session data
- Authentication: only serve admin app javascript files to logged-in admins
- Rollout / Flipper: only serve prototype app code to beta-testers

This is already possible and works. The issue is whether it belongs in the readme. 

I think it's nice, because it took me a while to piece together how to add a few before-filters, and it adds only the new controller to the application. 

On the other hand, it's more text, and there might be some reason not to encourage people to extend the controller?

If it's accepted I'll add a test (feature spec) before it's merged.
