### PR TITLE
Fix nil error when running rake ember:install

### DIFF
--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -65,7 +65,7 @@ module EmberCli
         bower_path = app_options.fetch(:bower_path) { which("bower") }
 
         bower_path.tap do |path|
-          unless Pathname(path).executable?
+          unless Pathname(path.to_s).executable?
             fail DependencyError.new <<-MSG.strip_heredoc
             Bower is required by EmberCLI
 


### PR DESCRIPTION
```
TypeError: no implicit conversion of nil into String
```

Ruby 2.3.0
Node v5.0.0
ember-cli-rails 0.7.0

I didn't have bower installed, so adding path.to_s allowed the code to tell me I needed to install bower.