### PR TITLE
Resolve `ember` executable with full path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 master
 ------
 
+* Resolve `ember` executable with full path within `node_modules`, instead of
+  depending on the presence of `node_modules/.bin`. [#395]
 * Introduce the idea of `App#mountable?` and `App#to_rack` for handling deploys
   that don't serve assets from the file system (Redis, for example).
 * Fix bug with generated `bin/heroku_install` script iterating through multiple
 * Don't mount route helpers at top-level. Instead, mount within the surrounding
   context with which they're invoked. [#381]
 
+[#395]: https://github.com/thoughtbot/ember-cli-rails/pull/395
 [#381]: https://github.com/thoughtbot/ember-cli-rails/pull/381
 
 0.7.0

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -37,7 +37,7 @@ module EmberCli
 
     def ember
       @ember ||= begin
-        root.join("node_modules", ".bin", "ember").tap do |path|
+        root.join("node_modules", "ember-cli", "bin", "ember").tap do |path|
           unless path.executable?
             fail DependencyError.new <<-MSG.strip_heredoc
               No `ember-cli` executable found for `#{app_name}`.

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -81,7 +81,7 @@ describe EmberCli::PathSet do
   describe "#ember" do
     it "is an executable child of #node_modules" do
       app = build_app
-      ember_path = rails_root.join(app.name, "node_modules", ".bin", "ember")
+      ember_path = rails_root.join(app.name, "node_modules", "ember-cli", "bin", "ember")
       create_executable(ember_path)
 
       path_set = build_path_set(app: app)


### PR DESCRIPTION
Closes [#392].

Resolve `ember` executable with full path within `node_modules`, instead
of depending on the presence of `node_modules/.bin`.

[#392]: #392