### PR TITLE
Enhance `rake ember:install` to fully reinstall if necessary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ master
 0.7.1
 -----
 
+* Enhance `rake ember:install` to fully reinstall if necessary.
 * Resolve `ember` executable with full path within `node_modules`, instead of
   depending on the presence of `node_modules/.bin`. [#395]
 * Introduce the idea of `App#mountable?` and `App#to_rack` for handling deploys

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -78,16 +78,16 @@ module EmberCli
       end
     end
 
-    def bower_deps
-      @bower_deps ||= root.join("bower_components")
+    def bower_components
+      @bower_components ||= root.join("bower_components")
     end
 
     def npm
       @npm ||= app_options.fetch(:npm_path) { which("npm") }
     end
 
-    def npm_deps
-      @npm_deps ||= root.join("node_modules")
+    def node_modules
+      @node_modules ||= root.join("node_modules")
     end
 
     def tee

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -78,8 +78,16 @@ module EmberCli
       end
     end
 
+    def bower_deps
+      @bower_deps ||= root.join("bower_components")
+    end
+
     def npm
       @npm ||= app_options.fetch(:npm_path) { which("npm") }
+    end
+
+    def npm_deps
+      @npm_deps ||= root.join("node_modules")
     end
 
     def tee

--- a/lib/ember_cli/runner.rb
+++ b/lib/ember_cli/runner.rb
@@ -9,10 +9,16 @@ module EmberCli
       @options = options
     end
 
-    def run!(command)
+    def run(command)
       output, status = Open3.capture2e(@env, command, @options)
 
       @out.write(output)
+
+      [output, status]
+    end
+
+    def run!(command)
+      output, status = run(command)
 
       unless status.success?
         @err.write <<-MSG.strip_heredoc
@@ -21,7 +27,7 @@ module EmberCli
             #{output}
         MSG
 
-        exit 1
+        exit status.exitstatus
       end
 
       true

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -54,6 +54,8 @@ module EmberCli
 
     def invalid_ember_dependencies?
       ! run("#{paths.ember} version")
+    rescue DependencyError
+      false
     end
 
     def clean_ember_dependencies!

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -37,7 +37,8 @@ module EmberCli
         run! "#{paths.bundler} install"
       end
 
-      run! "#{paths.ember} version || rm -rf #{paths.node_modules} #{paths.bower_components}"
+      clean_ember_dependencies! if invalid_ember_dependencies?
+
       run! "#{paths.npm} prune && #{paths.npm} install"
       run! "#{paths.bower} prune && #{paths.bower} install"
     end
@@ -50,6 +51,21 @@ module EmberCli
 
     attr_accessor :pid
     attr_reader :ember, :env, :options, :paths
+
+    def invalid_ember_dependencies?
+      ! run("#{paths.ember} version")
+    end
+
+    def clean_ember_dependencies!
+      ember_dependency_directories.select(&:exist?).each(&:rmtree)
+    end
+
+    def ember_dependency_directories
+      [
+        paths.node_modules,
+        paths.bower_components,
+      ]
+    end
 
     def spawn(command)
       Kernel.spawn(

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -37,6 +37,7 @@ module EmberCli
         exec "#{paths.bundler} install"
       end
 
+      exec "#{paths.ember} version || rm -rf #{paths.npm_deps} #{paths.bower_deps}"
       exec "#{paths.npm} prune && #{paths.npm} install"
       exec "#{paths.bower} prune && #{paths.bower} install"
     end

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -14,7 +14,7 @@ module EmberCli
     end
 
     def compile
-      exec ember.build
+      run! ember.build
     end
 
     def build_and_watch
@@ -34,16 +34,16 @@ module EmberCli
 
     def install
       if paths.gemfile.exist?
-        exec "#{paths.bundler} install"
+        run! "#{paths.bundler} install"
       end
 
-      exec "#{paths.ember} version || rm -rf #{paths.npm_deps} #{paths.bower_deps}"
-      exec "#{paths.npm} prune && #{paths.npm} install"
-      exec "#{paths.bower} prune && #{paths.bower} install"
+      run! "#{paths.ember} version || rm -rf #{paths.npm_deps} #{paths.bower_deps}"
+      run! "#{paths.npm} prune && #{paths.npm} install"
+      run! "#{paths.bower} prune && #{paths.bower} install"
     end
 
     def test
-      exec ember.test
+      run! ember.test
     end
 
     private
@@ -60,7 +60,7 @@ module EmberCli
       ) || exit(1)
     end
 
-    def exec(command)
+    def run!(command)
       Runner.new(
         options: { chdir: paths.root.to_s },
         out: paths.log,

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -37,7 +37,9 @@ module EmberCli
         run! "#{paths.bundler} install"
       end
 
-      clean_ember_dependencies! if invalid_ember_dependencies?
+      if invalid_ember_dependencies?
+        clean_ember_dependencies!
+      end
 
       run! "#{paths.npm} prune && #{paths.npm} install"
       run! "#{paths.bower} prune && #{paths.bower} install"
@@ -52,8 +54,10 @@ module EmberCli
     attr_accessor :pid
     attr_reader :ember, :env, :options, :paths
 
+    delegate :run, :run!, to: :runner
+
     def invalid_ember_dependencies?
-      ! run("#{paths.ember} version")
+      !run("#{paths.ember} version")
     rescue DependencyError
       false
     end
@@ -77,8 +81,6 @@ module EmberCli
         err: paths.build_error_file.to_s,
       ) || exit(1)
     end
-
-    delegate :run, :run!, to: :runner
 
     def runner
       Runner.new(

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -37,7 +37,7 @@ module EmberCli
         run! "#{paths.bundler} install"
       end
 
-      run! "#{paths.ember} version || rm -rf #{paths.npm_deps} #{paths.bower_deps}"
+      run! "#{paths.ember} version || rm -rf #{paths.node_modules} #{paths.bower_components}"
       run! "#{paths.npm} prune && #{paths.npm} install"
       run! "#{paths.bower} prune && #{paths.bower} install"
     end

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -60,13 +60,15 @@ module EmberCli
       ) || exit(1)
     end
 
-    def run!(command)
+    delegate :run, :run!, to: :runner
+
+    def runner
       Runner.new(
         options: { chdir: paths.root.to_s },
         out: paths.log,
         err: $stderr,
         env: env,
-      ).run!(command)
+      )
     end
 
     def running?

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -127,6 +127,16 @@ describe EmberCli::PathSet do
     end
   end
 
+  describe "#bower_deps" do
+    it "is a child of #root" do
+      app = build_app(name: "foo")
+
+      path_set = build_path_set(app: app)
+
+      expect(path_set.bower_deps).to eq rails_root.join("foo", "bower_components")
+    end
+  end
+
   describe "#npm" do
     it "can be overridden" do
       app = build_app(options: { npm_path: "npm-path" })
@@ -142,6 +152,16 @@ describe EmberCli::PathSet do
       path_set = build_path_set
 
       expect(path_set.npm).to eq "npm-path"
+    end
+  end
+
+  describe "#npm_deps" do
+    it "is a child of #root" do
+      app = build_app(name: "foo")
+
+      path_set = build_path_set(app: app)
+
+      expect(path_set.npm_deps).to eq rails_root.join("foo", "node_modules")
     end
   end
 

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -127,13 +127,14 @@ describe EmberCli::PathSet do
     end
   end
 
-  describe "#bower_deps" do
+  describe "#bower_components" do
     it "is a child of #root" do
       app = build_app(name: "foo")
 
       path_set = build_path_set(app: app)
 
-      expect(path_set.bower_deps).to eq rails_root.join("foo", "bower_components")
+      expect(path_set.bower_components).
+        to eq rails_root.join("foo", "bower_components")
     end
   end
 
@@ -155,13 +156,13 @@ describe EmberCli::PathSet do
     end
   end
 
-  describe "#npm_deps" do
+  describe "#node_modules" do
     it "is a child of #root" do
       app = build_app(name: "foo")
 
       path_set = build_path_set(app: app)
 
-      expect(path_set.npm_deps).to eq rails_root.join("foo", "node_modules")
+      expect(path_set.node_modules).to eq rails_root.join("foo", "node_modules")
     end
   end
 


### PR DESCRIPTION
Ember CLI ships with ember-cli-dependency-checker, which provides the
`ember version` command, which is akin to `bundle check`. This commit enhances
the ember:install rake task to `rm -rf node_modules bower_components` before
installing if `ember version` returns non-zero. This (helped further by npm
shrinkwrap) works to ensure that every machine has the same dependencies.

Closes [#394].

[#394]: https://github.com/thoughtbot/ember-cli-rails/issues/394