### PR TITLE
Add Rails 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ cache: bundler
 notifications:
   email: false
 rvm:
-- 2.3.0
-- 2.2
-- 2.1
-- jruby-9.0.3.0
+  - 2.3.0
+  - 2.2.2
+  - jruby-9.0.3.0
 before_install:
-- echo '--colour' > ~/.rspec
-- 'echo ''gem: --no-document'' > ~/.gemrc'
+  - echo '--colour' > ~/.rspec
+  - 'echo ''gem: --no-document'' > ~/.gemrc'
 before_script: bin/setup
 script: bin/rake
 env:
@@ -19,3 +18,8 @@ env:
 gemfile:
   - gemfiles/4.1.gemfile
   - gemfiles/4.2.gemfile
+  - gemfiles/5.0.0.gemfile
+  - gemfiles/master.gemfile
+matrix:
+  allow_failures:
+    - rvm: jruby-9.0.3.0

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,15 @@
-appraise "3.2" do
-  gem "rails", git: "https://github.com/rails/rails.git", branch: "3-2-stable"
-end
-
 appraise "4.1" do
   gem "rails", "~> 4.1.1"
 end
 
 appraise "4.2" do
   gem "rails", "~> 4.2.1"
+end
+
+appraise "5.0.0" do
+  gem "rails", "5.0.0"
+end
+
+appraise "master" do
+  gem "rails", git: "https://github.com/rails/rails.git", branch: "master"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 master
 ------
 
+* `EmberCli::EmberController` now inherits from `ActionController::Base` instead
+  of `ApplicationController`. [#400]
+* Remove support for Ruby 2.1.x. [#400]
 * Don't route requests to `/rails/info` through the mounted Ember application.
 
 0.7.4
@@ -33,6 +36,7 @@ master
 * `EmberCli::Deploy::File` serves assets with Rails' `static_cache_control`
   value. [#403]
 
+[#400]: https://github.com/thoughtbot/ember-cli-rails/pull/400
 [#396]: https://github.com/thoughtbot/ember-cli-rails/pull/396
 [#403]: https://github.com/thoughtbot/ember-cli-rails/pull/403
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ gem "rails", "4.2.4"
 gem "pry"
 
 group :development, :test do
-  gem "high_voltage", "~> 2.4.0"
-  gem "rspec-rails", "~> 3.3.0"
+  gem "high_voltage", "~> 3.0.0"
+  gem "rspec-rails", "~> 3.5.0"
 end
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ This project supports:
 
 This project supports:
 
-* Ruby versions `>= 2.1.0`
+* Ruby versions `>= 2.2.0`
 * Rails versions `>=4.1.x`.
 
 To learn more about supported versions and upgrades, read the [upgrading guide].

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,12 @@ Additionally, this codebase makes use of [(required) keyword arguments][kwargs].
 From `ember-cli-rails@0.4.0` and on, we will no longer support versions of Ruby
 prior to `2.1.0`.
 
+`ember-cli-rails@0.8.0` adds support for Rails 5, which depends on `rack@2.0.x`,
+which **requires** Ruby `2.2.2` or greater.
+
+From `ember-cli-rails@0.8.0` and on, we will no longer support versions of Ruby
+prior to `2.2.2`.
+
 To use `ember-cli-rails` with older versions of Ruby, try the `0.3.x` series.
 
 [kwargs]: https://robots.thoughtbot.com/ruby-2-keyword-arguments

--- a/app/controller/ember_cli/ember_controller.rb
+++ b/app/controller/ember_cli/ember_controller.rb
@@ -3,10 +3,5 @@ module EmberCli
     def index
       render layout: false
     end
-
-    def ember_app
-      params[:ember_app]
-    end
-    helper_method :ember_app
   end
 end

--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -8,6 +8,6 @@ module EmberRailsHelper
 
     head, body = markup_capturer.capture
 
-    render html: EmberCli[name].index_html(head: head, body: body).html_safe
+    render text: EmberCli[name].index_html(head: head, body: body).html_safe
   end
 end

--- a/app/views/ember_cli/ember/index.html.erb
+++ b/app/views/ember_cli/ember/index.html.erb
@@ -1,4 +1,4 @@
-<%= render_ember_app ember_app do |head| %>
+<%= render_ember_app params[:ember_app] do |head| %>
   <% head.append do %>
     <%= csrf_meta_tags %>
   <% end %>

--- a/bin/clean
+++ b/bin/clean
@@ -2,4 +2,4 @@
 
 set -e
 
-rm -rf spec/dummy/my-app
+rm -rf spec/dummy/{my-app,tmp}

--- a/bin/setup
+++ b/bin/setup
@@ -13,21 +13,6 @@ if ! command -v bower > /dev/null; then
   npm install -g bower
 fi
 
-if ! [ -d spec/dummy/my-app ]; then
-  git clone https://github.com/ember-cli/ember-new-output.git spec/dummy/my-app
+bin/setup_ember spec/dummy/my-app
 
-  bin/setup_ember
-fi
-
-# Only if this isn't CI
-if [ -z "$CI" ]; then
-  bin/appraisal install
-fi
-
-root="$(pwd)"
-
-cd ${root}/spec/dummy/my-app &&
-  npm install --save-dev ember-cli-rails-addon@rondale-sc/ember-cli-rails-addon
-  bower install
-
-cd ${root}/spec/dummy && bundle exec rake ember:install
+cd spec/dummy && bundle exec rake ember:install

--- a/bin/setup_ember
+++ b/bin/setup_ember
@@ -2,13 +2,25 @@
 
 set -e
 
-# make router catchall routes
-sed -i -e 's/auto/hash/' spec/dummy/my-app/config/environment.js
+setup_ember() {
+  local target="${1-spec/dummy/my-app}"
 
-# add text to a template
-echo 'Welcome to Ember' >> spec/dummy/my-app/app/templates/application.hbs
+  if ! [ -d $target ]; then
+    git clone -b stable https://github.com/ember-cli/ember-new-output.git $target
 
-# add an image to a template
-echo '<img src="assets/logo.png">' >> spec/dummy/my-app/app/templates/application.hbs
-mkdir -p spec/dummy/my-app/public/assets
-cp spec/fixtures/logo.png spec/dummy/my-app/public/assets
+    # make router catchall routes
+    sed -i -e 's/auto/hash/' $target/config/environment.js
+
+    # add an image to a template
+    echo '<p>Welcome to Ember</p>' >> $target/app/templates/application.hbs
+    echo '<img src="assets/logo.png">' >> $target/app/templates/application.hbs
+    mkdir -p $target/public/assets
+    cp spec/fixtures/logo.png $target/public/assets
+
+    cd $target &&
+      npm install --save-dev ember-cli-rails-addon@rondale-sc/ember-cli-rails-addon
+      bower install
+  fi
+}
+
+setup_ember

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |spec|
   spec.license  = "MIT"
   spec.files    = Dir["README.md", "CHANGELOG.md", "LICENSE.txt", "{lib,app,config}/**/*"]
 
-  spec.required_ruby_version = ">= 2.1.0"
+  spec.required_ruby_version = ">= 2.2.0"
 
   spec.add_dependency "ember-cli-rails-assets", "~> 0.6.2"
-  spec.add_dependency "railties", ">= 3.2", "< 5"
+  spec.add_dependency "railties", ">= 3.2"
   spec.add_dependency "cocaine", "~> 0.5.8"
   spec.add_dependency "html_page", "~> 0.1.0"
 end

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -7,8 +7,8 @@ gem "rails", "~> 4.2.1"
 gem "pry"
 
 group :development, :test do
-  gem "high_voltage", "~> 2.4.0"
-  gem "rspec-rails", "~> 3.3.0"
+  gem "high_voltage", "~> 3.0.0"
+  gem "rspec-rails", "~> 3.5.0"
 end
 
 group :test do

--- a/gemfiles/5.0.0.gemfile
+++ b/gemfiles/5.0.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "rails", "~> 4.1.1"
+gem "rails", "5.0.0"
 gem "pry"
 
 group :development, :test do

--- a/gemfiles/master.gemfile
+++ b/gemfiles/master.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "rails", "~> 4.1.1"
+gem "rails", :git => "https://github.com/rails/rails.git", :branch => "master"
 gem "pry"
 
 group :development, :test do

--- a/spec/lib/ember_cli/app_spec.rb
+++ b/spec/lib/ember_cli/app_spec.rb
@@ -27,7 +27,7 @@ describe EmberCli::App do
 
   describe "#compile" do
     it "exits with exit status of 0" do
-      passed = silence_stdout { EmberCli["my-app"].compile }
+      passed = EmberCli["my-app"].compile
 
       expect(passed).to be true
     end
@@ -35,7 +35,7 @@ describe EmberCli::App do
 
   describe "#test" do
     it "exits with exit status of 0" do
-      passed = silence_stdout { EmberCli["my-app"].test }
+      passed = EmberCli["my-app"].test
 
       expect(passed).to be true
     end
@@ -62,12 +62,6 @@ describe EmberCli::App do
       dist_path = app.dist_path
 
       expect(dist_path).to eq dist_path
-    end
-  end
-
-  def silence_stdout
-    silence_stream($stdout) do
-      yield
     end
   end
 


### PR DESCRIPTION
Closes [#376].
	
**Improve `setup_ember` script**

* Don't overwrite `gemfiles/` changes with `appraisal install`
* Localize Ember setup to `bin/setup_ember`
* Always invoke, let `bin/setup_ember` decide whether or not to no-op

Required changes
----------------

Run test suite against the latest `5.0.0.betaX` and `master` branches of
[`rails/rails`][rails].

Since `EmberController` extends `ApplicationController`, which can now
extend from either `ActionController::Base` (which implements
`helper_method`) and `ActionController::API` (which doesn't implement
`helper_method`), we can't depend on that API existing.

Remove call to `helper_method` from `EmberController`, as it is no
longer supported.

**Fix `EmberCli::EmberController` inheritance**

The `EmberCli::EmberController` used to inherit from
`ApplicationController` in order to reap the benefits of
application-wide configurations and behavior (such as
authentication-based `before_action` calls and other macros).

Unfortunately, with the introduction of Rails 5's `rails new --api`,
applications' `ApplicationController` can now inherit from
[`ActionController::API`][api], which doesn't serve HTML by default.

To support Rails 5's default `--api` behavior,
`EmberCli::EmberController` must inherit from `ActionController::Base`,
forcing the controller to forfeit all the benefits of sharing behavior
with `ApplicationController`.

[api]: http://edgeapi.rubyonrails.org/classes/ActionController/API.html

Support changes
---------------

Rails 5 depends on `rack@2.0.x`, which **requires** Ruby `2.2.2` or
greater.

In order to support Rails 5, we will no longer support versions of Ruby
prior to `2.2.2`.

[#376]: #376
[rails]: https://github.com/rails/rails

