### PR TITLE
Configure `EmberCli::Deploy::File` cache headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 master
 ------
 
+* `EmberCli::Deploy::File` serves assets with Rails' `static_cache_control`
+  value. [#403]
+
+[#403]: https://github.com/thoughtbot/ember-cli-rails/pull/403
+
 0.7.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,22 @@ As long as your [CDN is configured to pull from your Rails application][dns-cdn]
 
 ### Deployment Strategies
 
-By default, EmberCLI-Rails will serve the `index.html` file that `ember build`
-produces.
+By default, EmberCLI-Rails uses a file-based deployment strategy that depends on
+the output of `ember build`.
+
+Using this deployment strategy, Rails will serve the `index.html` file and other
+assets that `ember build` produces.
+
+These EmberCLI-generated assets are served with the same `Cache-Control` headers
+as Rails' other static files:
+
+```rb
+# config/environments/production.rb
+Rails.application.configure do
+  # serve static files with cache headers set to expire in 1 year
+  config.static_cache_control = "public, max-age=31622400"
+end
+```
 
 If you need to override this behavior (for instance, if you're using
 [`ember-cli-deploy`'s "Lightning Fast Deployment"][lightning] strategy in

--- a/lib/ember_cli/deploy/file.rb
+++ b/lib/ember_cli/deploy/file.rb
@@ -13,7 +13,7 @@ module EmberCli
       end
 
       def to_rack
-        Rack::File.new(app.dist_path.to_s)
+        Rack::File.new(app.dist_path.to_s, rack_headers)
       end
 
       def index_html
@@ -27,6 +27,12 @@ module EmberCli
       private
 
       attr_reader :app
+
+      def rack_headers
+        {
+          "Cache-Control" => Rails.configuration.static_cache_control,
+        }
+      end
 
       def check_for_error_and_raise!
         app.check_for_errors!

--- a/spec/dummy/application.rb
+++ b/spec/dummy/application.rb
@@ -7,6 +7,8 @@ Bundler.require(*Rails.groups)
 
 module Dummy
   class Application < Rails::Application
+    CACHE_CONTROL_FIVE_MINUTES = "public, max-age=300".freeze
+
     config.root = File.expand_path("..", __FILE__).freeze
     config.eager_load = false
 
@@ -22,6 +24,8 @@ module Dummy
 
     # Print deprecation notices to the stderr.
     config.active_support.deprecation = :stderr
+
+    config.static_cache_control = CACHE_CONTROL_FIVE_MINUTES
 
     config.secret_token = "SECRET_TOKEN_IS_MIN_30_CHARS_LONG"
     config.secret_key_base = "SECRET_KEY_BASE"

--- a/spec/requests/assets/my-app.js_spec.rb
+++ b/spec/requests/assets/my-app.js_spec.rb
@@ -1,0 +1,17 @@
+describe "GET assets/my-app.js" do
+  it "responds with the 'Cache-Control' header from Rails" do
+    build_ember_cli_assets
+
+    get "/assets/my-app.js"
+
+    expect(headers["Cache-Control"]).to eq(cache_for_five_minutes)
+  end
+
+  def build_ember_cli_assets
+    EmberCli["my-app"].build
+  end
+
+  def cache_for_five_minutes
+    Dummy::Application::CACHE_CONTROL_FIVE_MINUTES
+  end
+end


### PR DESCRIPTION
Closes [#401].

Previously, requests for Ember assets were being proxied through
`EmberCli::Deploy::File` Rack middleware without the HTTP
`Cache-Control` header.

Ember `production` builds digest the filenames of images/css/js/etc.
This makes these files highly cachable.

This commit configures the underlying `Rack::File` middleware to serve
assets with the `Cache-Control` header set by Rails.

[#401]: https://github.com/thoughtbot/ember-cli-rails/issues/401