### PR TITLE
Fail `ember:compile` if build subprocess fails

### DIFF
--- a/lib/ember_cli/command.rb
+++ b/lib/ember_cli/command.rb
@@ -14,7 +14,7 @@ module EmberCli
     end
 
     def build(watch: false)
-      "set -o pipefail; #{ember_build(watch: watch)} | #{tee}"
+      "set -e; #{ember_build(watch: watch)} | #{tee}"
     end
 
     private

--- a/lib/ember_cli/command.rb
+++ b/lib/ember_cli/command.rb
@@ -14,7 +14,7 @@ module EmberCli
     end
 
     def build(watch: false)
-      "#{ember_build(watch: watch)} | #{tee}"
+      "set -o pipefail; #{ember_build(watch: watch)} | #{tee}"
     end
 
     private

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -25,6 +25,13 @@ describe EmberCli::Command do
       expect(command.build).to match(%r{\| path/to/tee -a 'path/to/log'})
     end
 
+    it "sets pipefail" do
+      paths = build_paths(tee: "path/to/tee", log: "path/to/log")
+      command = build_command(paths: paths)
+
+      expect(command.build).to start_with("set -o pipefail;")
+    end
+
     context "when building in production" do
       it "includes the `--environment production` flag" do
         paths = build_paths

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -29,7 +29,7 @@ describe EmberCli::Command do
       paths = build_paths(tee: "path/to/tee", log: "path/to/log")
       command = build_command(paths: paths)
 
-      expect(command.build).to start_with("set -o pipefail;")
+      expect(command.build).to start_with("set -e;")
     end
 
     context "when building in production" do


### PR DESCRIPTION
Closes #417.

The following is the command `ember-cli-rails` generates for `rake
ember:compile`. It was generated using [the example application][repo].

```bash
/Users/seanpdoyle/src/ember-cli-rails-heroku-example/frontend/node_modules/.bin/ember build --environment 'development' --output-path '/Users/seanpdoyle/src/ember-cli-rails-heroku-example/tmp/ember-cli/apps/frontend' | /usr/bin/tee -a '/Users/seanpdoyle/src/ember-cli-rails-heroku-example/log/ember-frontend.development.log'
```

Pipes are streaming, so the pipe to `tee` will open before the first
program finishes writing, potentially ignoring a non-zero exit status.

The solution is to set the [`pipefail`][docs] option for the generated
sub-command.

[repo]: https://github.com/seanpdoyle/ember-cli-rails-heroku-example
[#417]: https://github.com/thoughtbot/ember-cli-rails/issues/417
[docs]: http://www.gnu.org/software/bash/manual/html_node/Pipelines.html