### PR TITLE
Remove dependency on `tee` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 master
 ------
 
+* Remove dependency on `tee`. Fixes bug [#417][#417].
+
+[#417]: https://github.com/thoughtbot/ember-cli-rails/issues/417
+
 0.7.2
 -----
 

--- a/lib/ember_cli/command.rb
+++ b/lib/ember_cli/command.rb
@@ -14,7 +14,7 @@ module EmberCli
     end
 
     def build(watch: false)
-      "#{ember_build(watch: watch)} | #{tee}"
+      ember_build(watch: watch)
     end
 
     private
@@ -23,12 +23,6 @@ module EmberCli
 
     def process_watcher
       options.fetch(:watcher) { EmberCli.configuration.watcher }
-    end
-
-    def tee
-      Cocaine::CommandLine.
-        new(paths.tee, "-a :log").
-        command(log: paths.log)
     end
 
     def ember_build(watch: false)

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -85,8 +85,8 @@ module EmberCli
     def runner
       Runner.new(
         options: { chdir: paths.root.to_s },
-        out: paths.log,
-        err: $stderr,
+        out: [$stdout, paths.log],
+        err: [$stderr],
         env: env,
       )
     end

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -18,13 +18,6 @@ describe EmberCli::Command do
       expect(command.build).to match(%r{path\/to\/ember build})
     end
 
-    it "pipes to `tee`" do
-      paths = build_paths(tee: "path/to/tee", log: "path/to/log")
-      command = build_command(paths: paths)
-
-      expect(command.build).to match(%r{\| path/to/tee -a 'path/to/log'})
-    end
-
     context "when building in production" do
       it "includes the `--environment production` flag" do
         paths = build_paths


### PR DESCRIPTION
Closes [#417].

Instead of piping output to the [`tee`][tee] command (which was
previously swallowing non-zero exit statuses), capture output
from `Open3.capture2e` and write to both the specified log file and
`STDOUT`.

[#417]: https://github.com/thoughtbot/ember-cli-rails/issues/417
[tee]: http://man7.org/linux/man-pages/man1/tee.1.html