### PR TITLE
Modify `Runner` to use `Open3.capture3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 master
 ------
 
-* Remove dependency on `tee`. Fixes bug [#417][#417].
+* Only write errors to `STDERR`. [#421]
+* Remove dependency on `tee`. Fixes bug [#417][#417]. [#420]
 
+[#421]: https://github.com/thoughtbot/ember-cli-rails/issues/421
+[#420]: https://github.com/thoughtbot/ember-cli-rails/issues/420
 [#417]: https://github.com/thoughtbot/ember-cli-rails/issues/417
 
 0.7.2

--- a/lib/ember_cli/app.rb
+++ b/lib/ember_cli/app.rb
@@ -36,9 +36,10 @@ module EmberCli
     def compile
       @compiled ||= begin
         prepare
-        @shell.compile
+        exit_status = @shell.compile
         @build.check!
-        true
+
+        exit_status.success?
       end
     end
 
@@ -71,7 +72,7 @@ module EmberCli
     def test
       prepare
 
-      @shell.test
+      @shell.test.success?
     end
 
     def check_for_errors!

--- a/spec/lib/ember_cli/app_spec.rb
+++ b/spec/lib/ember_cli/app_spec.rb
@@ -27,7 +27,7 @@ describe EmberCli::App do
 
   describe "#compile" do
     it "exits with exit status of 0" do
-      passed = EmberCli["my-app"].compile
+      passed = silence_stdout { EmberCli["my-app"].compile }
 
       expect(passed).to be true
     end
@@ -35,7 +35,7 @@ describe EmberCli::App do
 
   describe "#test" do
     it "exits with exit status of 0" do
-      passed = EmberCli["my-app"].test
+      passed = silence_stdout { EmberCli["my-app"].test }
 
       expect(passed).to be true
     end
@@ -62,6 +62,12 @@ describe EmberCli::App do
       dist_path = app.dist_path
 
       expect(dist_path).to eq dist_path
+    end
+  end
+
+  def silence_stdout
+    silence_stream($stdout) do
+      yield
     end
   end
 


### PR DESCRIPTION
[`Open3.capture3`][docs] captures `STDOUT` and `STDERR`, allowing the
`Runner` to manually redirect their output.

This commit modified `Runner` to **only** output errors to `STDERR`
(instead of to both `STDOUT` and `STDERR`).

[docs]: http://ruby-doc.org/stdlib-1.9.3/libdoc/open3/rdoc/Open3.html#method-c-capture3