### PR TITLE
Update `ember-cli-rails-assets` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 master
 ------
 
+* Update `ember-cli-rails-assets` dependency. [#422]
 * Only write errors to `STDERR`. [#421]
 * Remove dependency on `tee`. Fixes bug [#417][#417]. [#420]
 
+[#422]: https://github.com/thoughtbot/ember-cli-rails/pull/422
 [#421]: https://github.com/thoughtbot/ember-cli-rails/issues/421
 [#420]: https://github.com/thoughtbot/ember-cli-rails/issues/420
 [#417]: https://github.com/thoughtbot/ember-cli-rails/issues/417

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
 
-  spec.add_dependency "ember-cli-rails-assets", ">= 0.6.1"
+  spec.add_dependency "ember-cli-rails-assets", "~> 0.6.2"
   spec.add_dependency "railties", ">= 3.2", "< 5"
   spec.add_dependency "cocaine", "~> 0.5.8"
   spec.add_dependency "html_page", "~> 0.1.0"


### PR DESCRIPTION
This will likely be the last [minor version][semver] of
`ember-cli-rails` that will depend directly on `ember-cli-rails-assets`.

[semver]: http://semver.org/