### PR TITLE
Redirect output across streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 master
 ------
 
+* Stream output instead of waiting until subprocesses finish. [#423]
 * Update `ember-cli-rails-assets` dependency. [#422]
 * Only write errors to `STDERR`. [#421]
-* Remove dependency on `tee`. Fixes bug [#417][#417]. [#420]
+* Remove dependency on `tee`. Fixes bug [#417]. [#420]
 
+[#423]: https://github.com/thoughtbot/ember-cli-rails/pull/423
 [#422]: https://github.com/thoughtbot/ember-cli-rails/pull/422
 [#421]: https://github.com/thoughtbot/ember-cli-rails/issues/421
 [#420]: https://github.com/thoughtbot/ember-cli-rails/issues/420

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -85,7 +85,7 @@ module EmberCli
     def runner
       Runner.new(
         options: { chdir: paths.root.to_s },
-        out: [$stdout, paths.log],
+        out: [$stdout, paths.log.open("a")],
         err: [$stderr],
         env: env,
       )


### PR DESCRIPTION

`Runner` will "stream" output to `STDOUT`, `STDERR`, and each of the
associated streams instead of waiting until the subprocesses complete.