### PR TITLE
Create Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+**Which operating system and version is the project developed on?**
+
+**Which version of [`ruby`][ruby] is the project developed on?**
+
+**Which version of [`npm`][npm] is the project developed on?**
+
+**Which version of [`ember-cli`][ember-cli] is the project developed on?**
+
+**What is the [`rails`][rails] version?**
+
+**What is the [`ember-cli-rails`][gem] version (from `Gemfile`)?**
+
+**What is the [`ember-cli-rails-addon`][addon] version (from `package.json`)?**
+
+**What are the contents of `config/initializers/ember.rb`?**
+
+**What are the contents of the Rails' view that renders the Ember application?**
+
+**How are the EmberCLI-related routes defined?**
+
+**How is the application deployed?**
+
+[ruby]: https://www.ruby-lang.org/
+[node]: https://nodejs.org/en/
+[npm]: https://www.npmjs.com/
+[ember-cli]: http://ember-cli.com/
+[rails]: https://github.com/rails/rails
+[gem]: https://github.com/thoughtbot/ember-cli-rails
+[addon]: https://github.com/rondale-sc/ember-cli-rails-addon/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,16 @@
+# Reporting an Issue
+
+When reporting an issue, please fill out the provided
+[GitHub issue template][template] to the best of your ability.
+
+This template helps this project's maintainers understand and respond to issues
+in a timely manner.
+
+Issues that don't attempt to answer the questions asked in the issue template
+will likely be closed until additional information is provided.
+
+[template]: .github/ISSUE_TEMPLATE.md
+
 # Contributing
 
 We love pull requests from everyone.


### PR DESCRIPTION
To increase the quality of both issue creation and issue triage,
introduce a [GitHub Issue Template][docs].

Once merged, issues that don't provide at least some of the context
requested by the template will likely be closed immediately until
additional information is provided.

[docs]: https://help.github.com/articles/creating-an-issue-template-for-your-repository/