### PR TITLE
Allow --silent option for commands to quiet the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ c.app :frontend, path: "~/projects/my-ember-app"
 - `path` - the path where your Ember CLI application is located. The default
   value is the name of your app in the Rails root.
 
+- `silent` - this provides `--silent` option for Ember CLI commands to control verbosity of their output.
+
 ```ruby
 EmberCli.configure do |c|
   c.app :adminpanel # path defaults to `Rails.root.join("adminpanel")`

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ EmberCli.configure do |c|
   c.app :adminpanel # path defaults to `Rails.root.join("adminpanel")`
   c.app :frontend,
     path: "/path/to/your/ember-cli-app/on/disk"
+  c.app :payments, silent: true # by default it's false
 end
 ```
 

--- a/lib/ember_cli/command.rb
+++ b/lib/ember_cli/command.rb
@@ -25,11 +25,16 @@ module EmberCli
       options.fetch(:watcher) { EmberCli.configuration.watcher }
     end
 
+    def silent?
+      options.fetch(:silent) { false }
+    end
+
     def ember_build(watch: false)
       line = Cocaine::CommandLine.new(paths.ember, [
         "build",
         ("--watch" if watch),
         ("--watcher :watcher" if process_watcher),
+        ("--silent" if silent?),
         "--environment :environment",
         "--output-path :output_path",
       ].compact.join(" "))

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -69,7 +69,7 @@ describe EmberCli::Command do
     end
 
     context "when configured to be silent" do
-      it "includes includes `--silent` flag" do
+      it "includes `--silent` flag" do
         paths = build_paths
         command = build_command(paths: paths, options: { silent: true })
 

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -54,6 +54,24 @@ describe EmberCli::Command do
       end
     end
 
+    context 'when configured not to be silent' do
+      it 'exludes the `--silent` flag' do
+        paths = build_paths
+        command = build_command(paths: paths, options: { silent: false })
+
+        expect(command.build).not_to match(/--silent/)
+      end
+    end
+
+    context 'when configured to be silent' do
+      it 'includes includes `--silent` flag' do
+        paths = build_paths
+        command = build_command(paths: paths, options: { silent: true })
+
+        expect(command.build).to match(/--silent/)
+      end
+    end
+
     context "when configured to watch" do
       it "includes the `--watch` flag" do
         paths = build_paths

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -57,6 +57,11 @@ describe EmberCli::Command do
     context 'when configured not to be silent' do
       it 'exludes the `--silent` flag' do
         paths = build_paths
+        command = build_command(paths: paths)
+
+        expect(command.build).not_to match(/--silent/)
+
+        paths = build_paths
         command = build_command(paths: paths, options: { silent: false })
 
         expect(command.build).not_to match(/--silent/)

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -54,8 +54,8 @@ describe EmberCli::Command do
       end
     end
 
-    context 'when configured not to be silent' do
-      it 'exludes the `--silent` flag' do
+    context "when configured not to be silent" do
+      it "exludes the `--silent` flag" do
         paths = build_paths
         command = build_command(paths: paths)
 
@@ -68,8 +68,8 @@ describe EmberCli::Command do
       end
     end
 
-    context 'when configured to be silent' do
-      it 'includes includes `--silent` flag' do
+    context "when configured to be silent" do
+      it "includes includes `--silent` flag" do
         paths = build_paths
         command = build_command(paths: paths, options: { silent: true })
 


### PR DESCRIPTION
In my case, cucumber specs output is disrupted a bit by the ember-cli build output, so hence the PR.