### PR TITLE
Ignore requests for /rails/info routes

### DIFF
--- a/lib/ember_cli/multi_constraint.rb
+++ b/lib/ember_cli/multi_constraint.rb
@@ -1,0 +1,11 @@
+module EmberCli
+  class MultiConstraint
+    def initialize(*constraints)
+      @constraints = constraints
+    end
+
+    def matches?(request)
+      @constraints.all? { |c| c.matches?(request) }
+    end
+  end
+end

--- a/lib/ember_cli/rails_info_constraint.rb
+++ b/lib/ember_cli/rails_info_constraint.rb
@@ -1,0 +1,7 @@
+module EmberCli
+  class RailsInfoConstraint
+    def matches?(request)
+      !request.fullpath.start_with?("/rails/info")
+    end
+  end
+end

--- a/lib/ember_cli/route_helpers.rb
+++ b/lib/ember_cli/route_helpers.rb
@@ -1,14 +1,10 @@
 require "ember_cli/html_constraint"
+require "ember_cli/multi_constraint"
 require "ember_cli/rails_info_constraint"
 
 module ActionDispatch
   module Routing
     class Mapper
-      MULTI_CONSTRAINT = -> (req) {
-        [::EmberCli::HtmlConstraint.new,
-         ::EmberCli::RailsInfoConstraint.new].all? { |c| c.matches?(req) }
-      }
-
       def mount_ember_app(app_name, to:, **options)
         routing_options = options.deep_merge(
           defaults: { ember_app: app_name },
@@ -20,7 +16,8 @@ module ActionDispatch
           format: :html,
         )
 
-        scope constraints: MULTI_CONSTRAINT do
+        scope constraints: ::EmberCli::MultiConstraint.new(::EmberCli::HtmlConstraint.new,
+                                                           ::EmberCli::RailsInfoConstraint.new) do
           get("#{to}(*rest)", routing_options)
         end
 

--- a/lib/ember_cli/route_helpers.rb
+++ b/lib/ember_cli/route_helpers.rb
@@ -1,8 +1,14 @@
 require "ember_cli/html_constraint"
+require "ember_cli/rails_info_constraint"
 
 module ActionDispatch
   module Routing
     class Mapper
+      MULTI_CONSTRAINT = -> (req) {
+        [::EmberCli::HtmlConstraint.new,
+         ::EmberCli::RailsInfoConstraint.new].all? { |c| c.matches?(req) }
+      }
+
       def mount_ember_app(app_name, to:, **options)
         routing_options = options.deep_merge(
           defaults: { ember_app: app_name },
@@ -14,7 +20,7 @@ module ActionDispatch
           format: :html,
         )
 
-        scope constraints: ::EmberCli::HtmlConstraint.new do
+        scope constraints: MULTI_CONSTRAINT do
           get("#{to}(*rest)", routing_options)
         end
 

--- a/spec/lib/ember_cli/multi_constraint_spec.rb
+++ b/spec/lib/ember_cli/multi_constraint_spec.rb
@@ -1,0 +1,25 @@
+require "ember_cli/multi_constraint"
+
+describe EmberCli::MultiConstraint do
+  subject(:multi_constraint) { described_class.new(child_1, child_2) }
+  let(:child_1) { double("Route Constraint") }
+  let(:child_2) { double("Route Constraint") }
+  let(:request) { instance_double("ActionDispatch::Request") }
+
+  describe "#matches?" do
+
+    it "is true when all constraints match" do
+      allow(child_1).to receive(:matches?).with(request) { true }
+      allow(child_2).to receive(:matches?).with(request) { true }
+
+      expect(multi_constraint.matches?(request)).to be true
+    end
+
+    it "is false when any constraint fails to match" do
+      allow(child_1).to receive(:matches?).with(request) { true }
+      allow(child_2).to receive(:matches?).with(request) { false }
+
+      expect(multi_constraint.matches?(request)).to be false
+    end
+  end
+end

--- a/spec/lib/ember_cli/rails_info_constraint_spec.rb
+++ b/spec/lib/ember_cli/rails_info_constraint_spec.rb
@@ -1,0 +1,29 @@
+require "ember_cli/rails_info_constraint"
+
+describe EmberCli::RailsInfoConstraint do
+  subject(:constraint) { described_class.new }
+
+  describe "#matches?" do
+    context %{when the path doesn't start with "/rails/info"} do
+      it "return true" do
+        rails_only_request = double(fullpath: "/rails")
+        railroads_request = double(fullpath: "/rails/roads")
+
+        expect(constraint.matches?(rails_only_request)).to be true
+        expect(constraint.matches?(railroads_request)).to be true
+      end
+    end
+
+    context %{when the path starts with "/rails/info"} do
+      it "return false" do
+        info_request = double(fullpath: "/rails/info")
+        properties_request = double(fullpath: "/rails/info/properties")
+        routes_request = double(fullpath: "/rails/info/routes")
+
+        expect(constraint.matches?(info_request)).to be false
+        expect(constraint.matches?(properties_request)).to be false
+        expect(constraint.matches?(routes_request)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
When mounting an Ember CLI app via `mount_ember_app`, the catch-all routes defined by Ember CLI Rails also catch requests to two of Rails' magic routes:

1. `/rails/info/routes` (which is also redirected to from `/rails/info`)
2. `/rails/info/properties`

This adds another constraint to the mounted Ember app that will ignore requests with a path starting with `/rails/info`. I'm not in love with this solution, and basically hacked it together to see if it's even functionality you'd like added to the gem. If so, we can work to clean up the implementation, add documentation, etc... If not, perhaps we can simply document this in the `README` and maybe include the constraint so others can apply it if they wish.

Let me know what I can do to help.