### PR TITLE
Use render html:, not render inline:

### DIFF
--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -8,6 +8,6 @@ module EmberRailsHelper
 
     head, body = markup_capturer.capture
 
-    render inline: EmberCli[name].index_html(head: head, body: body)
+    render html: EmberCli[name].index_html(head: head, body: body).html_safe
   end
 end


### PR DESCRIPTION
Render inline compiles a template and uses more memory.
It also takes slightly more time.

See: https://github.com/thoughtbot/ember-cli-rails/issues/451