### PR TITLE
Fix dependencies check for compile command

### DIFF
--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -63,14 +63,14 @@ module EmberCli
     end
 
     def clean_ember_dependencies!
-      ember_dependency_directories.select(&:exist?).each(&:rmtree)
+      ember_dependency_directories.flat_map(&:children).each(&:rmtree)
     end
 
     def ember_dependency_directories
       [
         paths.node_modules,
         paths.bower_components,
-      ]
+      ].select(&:exist?)
     end
 
     def spawn(command)

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -57,7 +57,7 @@ module EmberCli
     delegate :run, :run!, to: :runner
 
     def invalid_ember_dependencies?
-      !run("#{paths.ember} version")
+      !run("#{paths.ember} version").success?
     rescue DependencyError
       false
     end


### PR DESCRIPTION
First commit fixes actual bug, while the second one improves `clean_ember_dependencies!` behavior when dependencies directory is a symlink.

We use shared directories for `node_modules` and `bower_components` in order to speed up deploys. This change make cleanup work for that case.

Thanks!