### PR TITLE
Make specs green again!

### DIFF
--- a/bin/setup_ember
+++ b/bin/setup_ember
@@ -5,6 +5,9 @@ set -e
 # make router catchall routes
 sed -i -e 's/auto/hash/' spec/dummy/my-app/config/environment.js
 
+# add text to a template
+echo 'Welcome to Ember' >> spec/dummy/my-app/app/templates/application.hbs
+
 # add an image to a template
 echo '<img src="assets/logo.png">' >> spec/dummy/my-app/app/templates/application.hbs
 mkdir -p spec/dummy/my-app/public/assets


### PR DESCRIPTION
Seems like `ember-cli-output` app does not include default
text in `applicition.hbs` template, so we add it anyway.