### PR TITLE
adding deployment performance tip for Capistrano deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ you're not using `nvm`, make sure the string you prepend to the `$PATH` variable
 contains the directory or directories that contain the `bower` and `npm`
 executables.
 
+#### For faster deployments
+Place the following in your deploy/<environment>.rb 
+```ruby
+set :linked_dirs, %w{frontend/node_modules frontend/bower_components}
+```
+to avoid rebuilding all the node modules and bower components with every deploy
+
 ## Override
 
 By default, routes defined by `ember_app` will be rendered with the internal

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Place the following in your deploy/<environment>.rb
 ```ruby
 set :linked_dirs, %w{<ember-app-name>/node_modules <ember-app-name>/bower_components}
 ```
-to avoid rebuilding all the node modules and bower components with every deploy. Replace `<ember-app-name>` with the name of your ember app (default is frontend).
+to avoid rebuilding all the node modules and bower components with every deploy. Replace `<ember-app-name>` with the name of your ember app (default is `frontend`).
 
 ## Override
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Place the following in your deploy/<environment>.rb
 ```ruby
 set :linked_dirs, %w{<ember-app-name>/node_modules <ember-app-name>/bower_components}
 ```
-to avoid rebuilding all the node modules and bower components with every deploy. Replace &lt;ember-app-name&gt; with the name of your ember app (default is frontend).
+to avoid rebuilding all the node modules and bower components with every deploy. Replace `<ember-app-name>` with the name of your ember app (default is frontend).
 
 ## Override
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Place the following in your deploy/<environment>.rb
 ```ruby
 set :linked_dirs, %w{<ember-app-name>/node_modules <ember-app-name>/bower_components}
 ```
-to avoid rebuilding all the node modules and bower components with every deploy. Replace <ember-app-name> with the name of your ember app (default is frontend).
+to avoid rebuilding all the node modules and bower components with every deploy. Replace &lt;ember-app-name&gt; with the name of your ember app (default is frontend).
 
 ## Override
 

--- a/README.md
+++ b/README.md
@@ -306,9 +306,9 @@ executables.
 #### For faster deployments
 Place the following in your deploy/<environment>.rb 
 ```ruby
-set :linked_dirs, %w{frontend/node_modules frontend/bower_components}
+set :linked_dirs, %w{<ember-app-name>/node_modules <ember-app-name>/bower_components}
 ```
-to avoid rebuilding all the node modules and bower components with every deploy
+to avoid rebuilding all the node modules and bower components with every deploy. Replace <ember-app-name> with the name of your ember app (default is frontend).
 
 ## Override
 


### PR DESCRIPTION
I've noticed that capistrano deployments rebuild bower and node modules from scratch each time, so I experimented with sharing those directories across deployments.  Seems to be working, so I thought I would update the Capistrano section with this tip for others. 

