### PR TITLE
Add support for detecting DEPRECATION: warnings

### DIFF
--- a/spec/lib/ember_cli/build_monitor_spec.rb
+++ b/spec/lib/ember_cli/build_monitor_spec.rb
@@ -56,11 +56,12 @@ describe EmberCli::BuildMonitor do
 
     context "when the error file only contains deprecation warnings" do
       it "does not raise a BuildError" do
-        error_file = error_file_with_contents([
-          "", # Blank line
-          "DEPRECATION: A warning",
-          "    at AStackTrace"
-        ])
+        error_file = error_file_with_contents(
+          [
+            "", # Blank line
+            "DEPRECATION: A warning",
+            "    at AStackTrace",
+          ])
         paths = build_paths(error_file)
         monitor = EmberCli::BuildMonitor.new(nil, paths)
 
@@ -70,11 +71,12 @@ describe EmberCli::BuildMonitor do
 
     context "when the error file contains a ASCII colored deprecation" do
       it "does not raise a BuildError" do
-        error_file = error_file_with_contents([
-          "", # Blank line
-          "\e[33mDEPRECATION: A warning",
-          "    at AStackTrace\e[39m"
-        ])
+        error_file = error_file_with_contents(
+          [
+            "", # Blank line
+            "\e[33mDEPRECATION: A warning",
+            "    at AStackTrace\e[39m",
+          ])
         paths = build_paths(error_file)
         monitor = EmberCli::BuildMonitor.new(nil, paths)
 
@@ -84,13 +86,14 @@ describe EmberCli::BuildMonitor do
 
     context "when the error file contains both errors & deprecation warnings" do
       it "raises a BuildError" do
-        error_file = error_file_with_contents([
-          "", # Blank line
-          "DEPRECATION: A warning",
-          "    at AStackTrace",
-          "", # Blank line
-          "SyntaxError: things went wrong"
-        ])
+        error_file = error_file_with_contents(
+          [
+            "", # Blank line
+            "DEPRECATION: A warning",
+            "    at AStackTrace",
+            "", # Blank line
+            "SyntaxError: things went wrong",
+          ])
         paths = build_paths(error_file)
         monitor = EmberCli::BuildMonitor.new("app-name", paths)
 


### PR DESCRIPTION
These warnings aren't build errors (the build is still successful), so we need to avoid treating such `DEPRECATION:` lines as indicating a build error occurred.

This fixes #464 - a problem I've encountered with a new project using ember-cli-rails 0.7.4, Ember CLI 2.6.2 and ember-cli-rails-addon 0.7.0 (which is the source of the deprecation warning).

A different solution has been presented in PR #465 - this PR differs in that it will still detect build errors that occur even when a deprecation warning is present. It also ensures the build error files is still cleared between builds.

Thanks to @victor95pc for your work on #465 - it helped steer me in the right direction for fixing this :)

For the curious (because this is something I wondered myself) - the STDERR output of `ember build` is used to detect a build error instead of the exit status because in development mode the build is run with `--watch` and it never exits for there to be an exit status to assess.