### PR TITLE
Add modules to `ember_cli/ember` controller

### DIFF
--- a/app/controller/ember_cli/ember_controller.rb
+++ b/app/controller/ember_cli/ember_controller.rb
@@ -1,5 +1,16 @@
 module EmberCli
   class EmberController < ::ApplicationController
+    unless ancestors.include? ActionController::Base
+      (
+        ActionController::Base::MODULES -
+        ActionController::API::MODULES
+      ).each do |controller_module|
+        include controller_module
+      end
+
+      helper EmberRailsHelper
+    end
+
     def index
       render layout: false
     end


### PR DESCRIPTION
Closes [#480].

When the `ApplicationController` extends `ActionController::API`, HTML
rendering modules and logic are omitted.

To make the `EmberCli::EmberController` capable of rendering the Ember
application's HTML, this commit ensures those modules are included when
necessary.

[#480]: https://github.com/thoughtbot/ember-cli-rails/issues/480