### PR TITLE
Support silent flag on ember:test

### DIFF
--- a/lib/ember_cli/command.rb
+++ b/lib/ember_cli/command.rb
@@ -8,9 +8,7 @@ module EmberCli
     end
 
     def test
-      line = Cocaine::CommandLine.new(paths.ember, "test --environment test")
-
-      line.command
+      ember_test
     end
 
     def build(watch: false)
@@ -27,6 +25,16 @@ module EmberCli
 
     def silent?
       options.fetch(:silent) { false }
+    end
+
+    def ember_test
+      line = Cocaine::CommandLine.new(paths.ember, [
+        "test",
+        ("--silent" if silent?),
+        "--environment test",
+      ].compact.join(" "))
+
+      line.command
     end
 
     def ember_build(watch: false)

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -8,6 +8,29 @@ describe EmberCli::Command do
 
       expect(command.test).to eq("path\/to\/ember test --environment test")
     end
+
+    context "when configured not to be silent" do
+      it "excludes the `--silent` flag" do
+        paths = build_paths
+        command = build_command(paths: paths)
+
+        expect(command.test).not_to match(/--silent/)
+
+        paths = build_paths
+        command = build_command(paths: paths, options: { silent: false })
+
+        expect(command.test).not_to match(/--silent/)
+      end
+    end
+
+    context "when configured to be silent" do
+      it "includes `--silent` flag" do
+        paths = build_paths
+        command = build_command(paths: paths, options: { silent: true })
+
+        expect(command.test).to match(/--silent/)
+      end
+    end
   end
 
   describe "#build" do
@@ -55,7 +78,7 @@ describe EmberCli::Command do
     end
 
     context "when configured not to be silent" do
-      it "exludes the `--silent` flag" do
+      it "excludes the `--silent` flag" do
         paths = build_paths
         command = build_command(paths: paths)
 


### PR DESCRIPTION
`ember test` supports the `--silent` command line option. This pr allows calling `rake ember:test --silent`.