### PR TITLE
Add support for yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ c.app :frontend, path: "~/projects/my-ember-app"
 
 - `silent` - this provides `--silent` option for Ember CLI commands to control verbosity of their output.
 
+- `yarn` - enables the [yarn](https://github.com/yarnpkg/yarn) package manager when installing dependencies
+
 ```ruby
 EmberCli.configure do |c|
   c.app :adminpanel # path defaults to `Rails.root.join("adminpanel")`
@@ -304,7 +306,7 @@ contains the directory or directories that contain the `bower` and `npm`
 executables.
 
 #### For faster deployments
-Place the following in your deploy/<environment>.rb 
+Place the following in your deploy/<environment>.rb
 ```ruby
 set :linked_dirs, %w{<ember-app-name>/node_modules <ember-app-name>/bower_components}
 ```

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -109,8 +109,11 @@ module EmberCli
     attr_reader :app, :ember_cli_root, :environment, :rails_root
 
     def package_manager
-      return "yarn" if yarn?
-      "npm"
+      if yarn?
+        "yarn"
+      else
+        "npm"
+      end
     end
 
     def yarn?

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -45,7 +45,7 @@ module EmberCli
               Install it:
 
                   $ cd #{root}
-                  $ npm install
+                  $ #{package_manager} install
             MSG
           end
         end
@@ -86,6 +86,12 @@ module EmberCli
       @npm ||= app_options.fetch(:npm_path) { which("npm") }
     end
 
+    def yarn
+      if yarn?
+        @yarn ||= app_options.fetch(:yarn_path) { which("yarn") }
+      end
+    end
+
     def node_modules
       @node_modules ||= root.join("node_modules")
     end
@@ -101,6 +107,15 @@ module EmberCli
     private
 
     attr_reader :app, :ember_cli_root, :environment, :rails_root
+
+    def package_manager
+      return "yarn" if yarn?
+      "npm"
+    end
+
+    def yarn?
+      app_options[:yarn] || app_options[:yarn_path]
+    end
 
     def app_name
       app.name

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -41,7 +41,11 @@ module EmberCli
         clean_ember_dependencies!
       end
 
-      run! "#{paths.npm} prune && #{paths.npm} install"
+      if paths.yarn
+        run! "#{paths.yarn} install"
+      else
+        run! "#{paths.npm} prune && #{paths.npm} install"
+      end
       run! "#{paths.bower} prune && #{paths.bower} install"
     end
 

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -46,6 +46,7 @@ module EmberCli
       else
         run! "#{paths.npm} prune && #{paths.npm} install"
       end
+
       run! "#{paths.bower} prune && #{paths.bower} install"
     end
 

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -156,6 +156,32 @@ describe EmberCli::PathSet do
     end
   end
 
+  describe "#yarn" do
+    it "is not enabled by default" do
+      path_set = build_path_set
+
+      expect(path_set.yarn).to be nil
+    end
+
+    it "can be overridden" do
+      app = build_app(options: { yarn_path: "yarn-path" })
+
+      path_set = build_path_set(app: app)
+
+      expect(path_set.yarn).to eq "yarn-path"
+    end
+
+    it "can be inferred from the $PATH" do
+      stub_which(yarn: "yarn-path")
+
+      app = build_app(options: { yarn: true })
+
+      path_set = build_path_set(app: app)
+
+      expect(path_set.yarn).to eq "yarn-path"
+    end
+  end
+
   describe "#node_modules" do
     it "is a child of #root" do
       app = build_app(name: "foo")


### PR DESCRIPTION
[yarn](https://github.com/yarnpkg/yarn) has significantly reduced the time it takes to install npm packages. Given the benefits of yarn, I've added opt-in support for using `yarn install` instead of `npm install`.

Enabling yarn can be done by either:
* Specifying the `yarn` option:
```ruby
EmberCli.configure do |c|
  c.app :frontend, yarn: true
end
```
* Specifying the `yarn_path`:
```ruby
EmberCli.configure do |c|
  c.app :frontend, yarn_path: "/home/app/bin/yarn"
end
```