### PR TITLE
baseURL deprecated in favor of rootURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Rails.application.routes.draw do
 end
 ```
 
-Then set each Ember application's `baseURL` to the mount point:
+Then set each Ember application's `rootURL` to the mount point:
 
 ```javascript
 // frontend/config/environment.js
@@ -475,7 +475,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'frontend',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     // ...
   }
 };
@@ -486,7 +486,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'admin_panel',
     environment: environment,
-    baseURL: '/admin_panel',  // originally '/'
+    rootURL: '/admin_panel',  // originally '/'
     // ...
   }
 };


### PR DESCRIPTION
Ran into this when configuring my ember-cli-rails Ember application under something other than `/`.  There is some history to this deprecation that can be found here and it's only relevant in ember-cli versions > 2.7. 

Check out this relevant official blog post: http://emberjs.com/blog/2016/04/28/baseURL.html