### PR TITLE
Support Rails 5 static file serving configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 master
 ------
 
+* Support Rails 5 static file serving configuration. [#499]
+
+[#499]: https://github.com/thoughtbot/ember-cli-rails/pull/499
+
 0.8.1
 -----
 

--- a/lib/ember_cli/deploy/file.rb
+++ b/lib/ember_cli/deploy/file.rb
@@ -29,9 +29,21 @@ module EmberCli
       attr_reader :app
 
       def rack_headers
-        {
-          "Cache-Control" => Rails.configuration.static_cache_control,
-        }
+        config = Rails.configuration
+
+        if config.respond_to?(:public_file_server) &&
+            config.public_file_server && config.public_file_server.headers
+          # Rails 5.
+          config.public_file_server.headers
+        elsif config.respond_to?(:static_cache_control)
+          # Rails 4.2 and below.
+          {
+            "Cache-Control" => Rails.configuration.static_cache_control,
+          }
+        else
+          # No specification.
+          {}
+        end
       end
 
       def check_for_error_and_raise!

--- a/spec/dummy/application.rb
+++ b/spec/dummy/application.rb
@@ -25,7 +25,13 @@ module Dummy
     # Print deprecation notices to the stderr.
     config.active_support.deprecation = :stderr
 
-    config.static_cache_control = CACHE_CONTROL_FIVE_MINUTES
+    if Rails.version >= "5"
+      config.public_file_server.headers = {
+        "Cache-Control" => CACHE_CONTROL_FIVE_MINUTES
+      }
+    else
+      config.static_cache_control = CACHE_CONTROL_FIVE_MINUTES
+    end
 
     config.secret_token = "SECRET_TOKEN_IS_MIN_30_CHARS_LONG"
     config.secret_key_base = "SECRET_KEY_BASE"


### PR DESCRIPTION
Source documenting the new Rails 5 configuration method: [Rails guides](http://guides.rubyonrails.org/asset_pipeline.html#cdns) -- look for section 4.4.2.3 CDNs and the Cache-Control Header

Thank you for the gem!