### PR TITLE
Improve EmberController inheritance change wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ master
 0.8.0
 -----
 
-* `EmberCli::EmberController` now inherits from `ActionController::Base` instead
-  of `ApplicationController`. [#400]
+* `EmberCli::EmberController` no longer assumes `ApplicationController`
+  inherits from`ActionController::Base`. [#400]
 * Remove support for Ruby 2.1.x. [#400]
 * Don't route requests to `/rails/info` through the mounted Ember application.
 


### PR DESCRIPTION
The previous wording implies that application-wide behavior would no longer apply to `EmberCli::EmberController`, due to inheritance change. But, `EmberCli::EmberController` still inherits from `ApplicationController`, it just no longer assumes that `ApplicationController` inherits from `ActionController::Base`.