### PR TITLE
Generate package with `bower` as a `dependencies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Generate `package.json` with `bower` as a `dependencies` value.
+
 0.8.3
 -----
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,6 @@ To configure your EmberCLI-Rails applications for Heroku:
 $ heroku buildpacks:clear
 $ heroku buildpacks:add --index 1 heroku/nodejs
 $ heroku buildpacks:add --index 2 heroku/ruby
-$ heroku config:set NPM_CONFIG_PRODUCTION=false
 $ heroku config:unset SKIP_EMBER
 ```
 

--- a/lib/generators/ember/heroku/templates/package.json.erb
+++ b/lib/generators/ember/heroku/templates/package.json.erb
@@ -2,7 +2,7 @@
   "scripts": {
     "postinstall": "./bin/heroku_install"
   },
-  "devDependencies": {
+  "dependencies": {
     "bower": "*"
   },
   "cacheDirectories": [


### PR DESCRIPTION
https://github.com/thoughtbot/ember-cli-rails/issues/506

The project used to recommend NPM-specific configrations [based on a
misunderstanding][#506] of how NPM managed project-local executables.

This commit generates a root-level `package.json` with the proper
configuration, and removes the `README`'s recommendation to set
`NPM_PRODUCTION=false` on Heroku.

[#506]: https://github.com/thoughtbot/ember-cli-rails/issues/506#issuecomment-267639410