### PR TITLE
Execute `bin/heroku_install` via `sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 master
 ------
 
+* Execute `bin/heroku_install` through `sh` [#512]
 * Generate `package.json` with `bower` as a `dependencies` value.
+
+[#512]: https://github.com/thoughtbot/ember-cli-rails/pull/512
 
 0.8.3
 -----

--- a/lib/generators/ember/heroku/templates/package.json.erb
+++ b/lib/generators/ember/heroku/templates/package.json.erb
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "postinstall": "./bin/heroku_install"
+    "postinstall": "sh bin/heroku_install"
   },
   "dependencies": {
     "bower": "*"


### PR DESCRIPTION
Closes [#511].

Be explicit about executing the Heroku setup script by invoking `sh`
directly.

[#511]: https://github.com/thoughtbot/ember-cli-rails/issues/511