### PR TITLE
Patch Rails 5.1 not supporting text option for render anymore

### DIFF
--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -8,6 +8,11 @@ module EmberRailsHelper
 
     head, body = markup_capturer.capture
 
-    render text: EmberCli[name].index_html(head: head, body: body).html_safe
+    template = EmberCli[name].index_html(head: head, body: body).html_safe
+    begin
+      render text: template
+    rescue ArgumentError
+      render body: template
+    end
   end
 end

--- a/app/helpers/ember_rails_helper.rb
+++ b/app/helpers/ember_rails_helper.rb
@@ -8,11 +8,6 @@ module EmberRailsHelper
 
     head, body = markup_capturer.capture
 
-    template = EmberCli[name].index_html(head: head, body: body).html_safe
-    begin
-      render text: template
-    rescue ArgumentError
-      render body: template
-    end
+    render html: EmberCli[name].index_html(head: head, body: body).html_safe
   end
 end


### PR DESCRIPTION
Ran into an exception while trying to use this with rails 5.1 - :text option is no longer supported by ActionView:: TemplateRenderer