### PR TITLE
Excempt Rails mailer preview routes in constraint

### DIFF
--- a/lib/ember_cli/ember_constraint.rb
+++ b/lib/ember_cli/ember_constraint.rb
@@ -7,7 +7,7 @@ module EmberCli
     private
 
     def rails_info_request?(request)
-      request.fullpath.start_with?("/rails/info")
+      request.fullpath.start_with?("/rails/info", "/rails/mailers")
     end
 
     def html_request?(request)


### PR DESCRIPTION
In order to preview mailers, you have to comment out the `ember-cli-rails` router helper, which is very inconvenient.

This ignores the route along with `/rails/info`.