### PR TITLE
Configure Travis to run the proper Node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 language: ruby
 sudo: false
-cache: bundler
+cache:
+  - bundler
 notifications:
   email: false
 rvm:
   - 2.3.0
   - 2.2.2
   - jruby-9.0.3.0
-before_install:
-  - echo '--colour' > ~/.rspec
-  - 'echo ''gem: --no-document'' > ~/.gemrc'
-before_script: bin/setup
+install: bin/setup_ci
+before_script:
+  - export PATH="$HOME/.nvm/versions/node/v${NODE_JS_VERSION}/bin:$PATH"
 script: bin/rake
 env:
   global:
-    secure: RbWKxwfpzyQ5uv/jYH68/0J3Y9xe7rQbGULsWZT98FxZcVWLoOFlPPITmnmEK32CjQUww8iMz50FRLxFNmXg8prt1KzpzikVdIZLmYg1NFShI8+JOFhJzwCuk/LLybNUmydejR58FJvV9gS8NYqMh5leFkDM3OwLxhWdcE8hDDQ=
+    - secure: RbWKxwfpzyQ5uv/jYH68/0J3Y9xe7rQbGULsWZT98FxZcVWLoOFlPPITmnmEK32CjQUww8iMz50FRLxFNmXg8prt1KzpzikVdIZLmYg1NFShI8+JOFhJzwCuk/LLybNUmydejR58FJvV9gS8NYqMh5leFkDM3OwLxhWdcE8hDDQ=
+    - NODE_JS_VERSION=7.10.0
 gemfile:
   - gemfiles/4.1.gemfile
   - gemfiles/4.2.gemfile

--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,7 @@
 
 set -e
 
-# Set up Ruby dependencies via Bundler
+echo '-- Set up Ruby dependencies via Bundler'
 gem install bundler --conservative
 bundle check || bundle install
 
@@ -15,4 +15,5 @@ fi
 
 bin/setup_ember spec/dummy/my-app
 
-cd spec/dummy && bundle exec rake ember:install
+echo '-- Install Ember dependencies'
+cd spec/dummy && bundle exec rake ember:install || true

--- a/bin/setup_ci
+++ b/bin/setup_ci
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+rm -rf ~/.nvm
+
+git clone https://github.com/creationix/nvm.git ~/.nvm
+
+source ~/.nvm/nvm.sh
+
+echo "$NODE_JS_VERSION" > .nvmrc
+
+nvm install "$NODE_JS_VERSION"
+
+nvm use "$NODE_JS_VERSION" || true
+
+nvm alias default "$NODE_JS_VERSION" || true
+
+node --version
+
+source bin/setup

--- a/bin/setup_ember
+++ b/bin/setup_ember
@@ -8,18 +8,25 @@ setup_ember() {
   if ! [ -d $target ]; then
     git clone -b stable https://github.com/ember-cli/ember-new-output.git $target
 
-    # make router catchall routes
+    echo '-- Make router catchall routes'
     sed -i -e 's/auto/hash/' $target/config/environment.js
 
-    # add an image to a template
-    echo '<p>Welcome to Ember</p>' >> $target/app/templates/application.hbs
-    echo '<img src="assets/logo.png">' >> $target/app/templates/application.hbs
+    echo '-- Add an image to a template'
+    cp spec/fixtures/application.hbs $target/app/templates/application.hbs
+
     mkdir -p $target/public/assets
     cp spec/fixtures/logo.png $target/public/assets
 
+    echo '-- Install ember-cli-rails-addon'
     cd $target &&
       npm install --save-dev ember-cli-rails-addon@rondale-sc/ember-cli-rails-addon
-      bower install
+
+    if [ -f "$target/bower.json" ]; then
+      echo '-- Install Bower dependencies'
+      cd $target && bower install
+    fi
+
+    echo '-- Successfully setup Ember'
   fi
 }
 

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -47,7 +47,7 @@ module EmberCli
         run! "#{paths.npm} prune && #{paths.npm} install"
       end
 
-      run! "#{paths.bower} prune && #{paths.bower} install"
+      run! "[ -f bower.json ] && #{paths.bower} prune && #{paths.bower} install"
     end
 
     def test

--- a/spec/fixtures/application.hbs
+++ b/spec/fixtures/application.hbs
@@ -1,0 +1,4 @@
+<p>Welcome to Ember</p>
+<img src="assets/logo.png">
+
+{{outlet}}

--- a/spec/lib/ember_cli/ember_constraint_spec.rb
+++ b/spec/lib/ember_cli/ember_constraint_spec.rb
@@ -4,20 +4,20 @@ describe EmberCli::EmberConstraint do
   describe "#matches?" do
     context %{when the format is "html"} do
       context "when the request path is for a Rails info page" do
-        it "returns false" do
+        it "returns a falsey value" do
           constraint = EmberCli::EmberConstraint.new
           request = build_html_request("/rails/info")
 
-          expect(constraint.matches?(request)).to be false
+          expect(constraint.matches?(request)).to be_falsey
         end
       end
 
       context "when the request path is not for a Rails info page" do
-        it "returns true" do
+        it "returns a truthy value" do
           constraint = EmberCli::EmberConstraint.new
           request = build_html_request("/foo")
 
-          expect(constraint.matches?(request)).to be true
+          expect(constraint.matches?(request)).to be_truthy
         end
       end
     end
@@ -27,24 +27,13 @@ describe EmberCli::EmberConstraint do
         constraint = EmberCli::EmberConstraint.new
         request = build_json_request
 
-        expect(constraint.matches?(request)).to be false
-      end
-    end
-
-    context %"when the format is empty or nil" do
-      it "return false" do
-        constraint = EmberCli::EmberConstraint.new
-        nil_request = build_request(format: nil)
-        empty_request = build_request(format: "")
-
-        expect(constraint.matches?(nil_request)).to be false
-        expect(constraint.matches?(empty_request)).to be false
+        expect(constraint.matches?(request)).to be_falsey
       end
     end
   end
 
   def build_request(format:, fullpath: :ignored)
-    double(format: format, fullpath: fullpath)
+    double(format: format ? Mime::Type.new(format) : nil, fullpath: fullpath)
   end
 
   def build_html_request(fullpath)


### PR DESCRIPTION
This commit configures Travis CI to run the setup and test suite using a
more modern version.

Additionally, correct a failure introduce by merging a PR without a
passing test suite 🤐.