### PR TITLE
Make `bower` an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 master
 ------
 
+* Don't require `bower` installation if `bower.json` is missing [#532]
+
+[#532]: https://github.com/thoughtbot/ember-cli-rails/pull/532
+
 0.8.5
 -----
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ To configure your EmberCLI-Rails applications for Heroku:
 1. Execute `rails generate ember:heroku`.
 1. Commit the newly generated files.
 1. [Add the NodeJS buildpack][buildpack] and configure NPM to include the
-   `bower` dependency's executable file.
+   `bower` dependency's executable file (if your build process requires
+   `bower`).
 
 ```sh
 $ heroku buildpacks:clear
@@ -328,11 +329,16 @@ contains the directory or directories that contain the `bower` and `npm`
 executables.
 
 #### For faster deployments
-Place the following in your deploy/<environment>.rb
+
+Place the following in your `deploy/<environment>.rb`
+
 ```ruby
 set :linked_dirs, %w{<ember-app-name>/node_modules <ember-app-name>/bower_components}
 ```
-to avoid rebuilding all the node modules and bower components with every deploy. Replace `<ember-app-name>` with the name of your ember app (default is `frontend`).
+
+to avoid rebuilding all the node modules and bower components with every deploy.
+Replace `<ember-app-name>` with the name of your ember app (default is
+`frontend`).
 
 ## Override
 

--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -35,6 +35,10 @@ module EmberCli
       @gemfile ||= root.join("Gemfile")
     end
 
+    def bower_json
+      ember_cli_root.join("bower.json")
+    end
+
     def ember
       @ember ||= begin
         root.join("node_modules", "ember-cli", "bin", "ember").tap do |path|
@@ -64,7 +68,7 @@ module EmberCli
     def bower
       @bower ||= begin
         path_for_executable("bower").tap do |bower_path|
-          if bower_path.blank? || !bower_path.executable?
+          if bower_json.exist? && (bower_path.blank? || !bower_path.executable?)
             fail DependencyError.new <<-MSG.strip_heredoc
                 Bower is required by EmberCLI
 

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -41,13 +41,15 @@ module EmberCli
         clean_ember_dependencies!
       end
 
-      if paths.yarn
+      if paths.yarn.present? && Pathname.new(paths.yarn).executable?
         run! "#{paths.yarn} install"
       else
         run! "#{paths.npm} prune && #{paths.npm} install"
       end
 
-      run! "[ -f bower.json ] && #{paths.bower} prune && #{paths.bower} install"
+      if paths.bower_json.exist?
+        run! "#{paths.bower} prune && #{paths.bower} install"
+      end
     end
 
     def test

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -119,14 +119,38 @@ describe EmberCli::PathSet do
     end
 
     context "when it is missing from the $PATH" do
-      it "raises a helpful exception" do
-        stub_which(bower: nil)
+      context "bower.json exists" do
+        it "raises a helpful exception" do
+          create_file(ember_cli_root.join("bower.json"))
+          stub_which(bower: nil)
+          path_set = build_path_set
 
-        path_set = build_path_set
+          expect { path_set.bower }.
+            to raise_error(EmberCli::DependencyError, /bower is required/i)
+        end
 
-        expect { path_set.bower }.
-          to raise_error(EmberCli::DependencyError, /bower is required/i)
+        context "bower.json is missing" do
+          it "returns nil" do
+            stub_which(bower: nil)
+            path_set = build_path_set
+
+            bower = path_set.bower
+
+            expect(bower).to be_nil
+          end
+        end
       end
+    end
+  end
+
+  describe "#bower_json" do
+    it "is a child of #root" do
+      app = build_app(name: "foo")
+      path_set = build_path_set(app: app)
+
+      bower_json = path_set.bower_json
+
+      expect(bower_json).to eq ember_cli_root.join("bower.json")
     end
   end
 
@@ -164,12 +188,6 @@ describe EmberCli::PathSet do
   end
 
   describe "#yarn" do
-    it "is not enabled by default" do
-      path_set = build_path_set
-
-      expect(path_set.yarn).to be nil
-    end
-
     it "can be overridden" do
       fake_yarn = create_executable(ember_cli_root.join("yarn"))
       app = build_app(options: { yarn_path: fake_yarn.to_s })
@@ -185,10 +203,22 @@ describe EmberCli::PathSet do
       stub_which(yarn: fake_yarn.to_s)
       app = build_app(options: { yarn: true })
       path_set = build_path_set(app: app)
+      create_executable(fake_yarn)
 
       yarn = path_set.yarn
 
       expect(yarn).to eq(fake_yarn).and(be_executable)
+    end
+
+    context "when the executable isn't installed on the system" do
+      it "returns nil" do
+        stub_which(yarn: nil)
+        path_set = build_path_set
+
+        yarn = path_set.yarn
+
+        expect(yarn).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
Closes [#531].

According to `bower` warning messages, the project is semi-deprecated:

```
While Bower is maintained, we recommend Yarn and Webpack for *new*
front-end projects! Yarn's advantage is security and reliability, and
Webpack's is support for both CommonJS and AMD projects. Currently
there's no migration path but we hope you'll help us figure out one.
```

As such, the build process will skip `bower install` and won't require a
`bower` if the application's `bower.json` file is missing.

[#531]: https://github.com/thoughtbot/ember-cli-rails/issues/531