### PR TITLE
Use `Pathname#new` instead of `Pathname()`

### DIFF
--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -46,6 +46,7 @@ module EmberCli
 
                   $ cd #{root}
                   $ #{package_manager} install
+
             MSG
           end
         end
@@ -65,7 +66,7 @@ module EmberCli
         bower_path = app_options.fetch(:bower_path) { which("bower") }
 
         bower_path.tap do |path|
-          unless Pathname(path.to_s).executable?
+          unless Pathname.new(path.to_s).executable?
             fail DependencyError.new <<-MSG.strip_heredoc
             Bower is required by EmberCLI
 

--- a/spec/lib/ember_cli/app_spec.rb
+++ b/spec/lib/ember_cli/app_spec.rb
@@ -43,7 +43,7 @@ describe EmberCli::App do
 
   describe "#root_path" do
     it "delegates to PathSet" do
-      root_path = Pathname(".")
+      root_path = Pathname.new(".")
       stub_paths(root: root_path)
       app = EmberCli::App.new("foo")
 
@@ -55,7 +55,7 @@ describe EmberCli::App do
 
   describe "#dist_path" do
     it "delegates to PathSet" do
-      dist_path = Pathname(".")
+      dist_path = Pathname.new(".")
       stub_paths(dist: dist_path)
       app = EmberCli::App.new("foo")
 


### PR DESCRIPTION
Although it [works the same way], `Pathname(...)` is an unfamiliar and
surprising syntax.

This commit changes all occurrences to use the constructor.

[works the same way]: https://ruby-doc.org/stdlib-2.1.2/libdoc/pathname/rdoc/Pathname.html#method-i-each_child