### PR TITLE
Add support for `rails@5.1`, drop `rails@4.1`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ env:
     - secure: RbWKxwfpzyQ5uv/jYH68/0J3Y9xe7rQbGULsWZT98FxZcVWLoOFlPPITmnmEK32CjQUww8iMz50FRLxFNmXg8prt1KzpzikVdIZLmYg1NFShI8+JOFhJzwCuk/LLybNUmydejR58FJvV9gS8NYqMh5leFkDM3OwLxhWdcE8hDDQ=
     - NODE_JS_VERSION=7.10.0
 gemfile:
-  - gemfiles/4.1.gemfile
   - gemfiles/4.2.gemfile
   - gemfiles/5.0.0.gemfile
+  - gemfiles/5.1.0.gemfile
+  - gemfiles/master.gemfile
 matrix:
   allow_failures:
     - rvm: jruby-9.0.3.0

--- a/Appraisals
+++ b/Appraisals
@@ -1,12 +1,12 @@
-appraise "4.1" do
-  gem "rails", "~> 4.1.1"
-end
-
 appraise "4.2" do
   gem "rails", "~> 4.2.1"
 end
 
 appraise "5.0.0" do
+  gem "rails", "5.0.0"
+end
+
+appraise "5.1.0" do
   gem "rails", "5.0.0"
 end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ master
   Next, execute `rake ember:heroku`. [#544]
 * Generate an empty `yarn.lock` so that Heroku understands that the
   application's deployment target requires `yarn`. Closes [#538]. [#540]
+* No longer support `rails < 4.2`. [#543]
+* Generate an empty `yarn.lock` so that Heroku understands that the
+  application's deployment target requires `yarn`. Closes [#538]. [#540]
 
+[#543]: https://github.com/thoughtbot/ember-cli-rails/pull/543
 [#544]: https://github.com/thoughtbot/ember-cli-rails/pull/544
 [#538]: https://github.com/thoughtbot/ember-cli-rails/issues/538
 [#540]: https://github.com/thoughtbot/ember-cli-rails/pull/540

--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ This project supports:
 This project supports:
 
 * Ruby versions `>= 2.2.0`
-* Rails versions `>=4.1.x`.
+* Rails versions `>=4.2.x`.
 
 To learn more about supported versions and upgrades, read the [upgrading guide].
 

--- a/gemfiles/5.1.0.gemfile
+++ b/gemfiles/5.1.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "rails", "~> 4.1.1"
+gem "rails", "5.1.0"
 gem "pry"
 
 group :development, :test do

--- a/lib/tasks/ember-cli.rake
+++ b/lib/tasks/ember-cli.rake
@@ -16,10 +16,5 @@ namespace :ember do
 end
 
 unless EmberCli.skip?
-  # Hook into assets:precompile:all for Rails 3.1+
-  if Rails::VERSION::MAJOR < 4
-    task "assets:precompile:all" => "ember:compile"
-  else
-    task "assets:precompile" => "ember:compile"
-  end
+  task "assets:precompile" => "ember:compile"
 end


### PR DESCRIPTION
With the release of `rails@5.1`, add explicit test coverage, in addition
to testing on `master`.

According to the [Ruby on Rails Maintenance Policy][policy], Rails 4.1
has reached its end of life stage [after the release of Rails
5.0][rails-5.0].

As such, this commit drops formal test coverage and support for Rails
versions prior to 4.2.

[policy]: http://guides.rubyonrails.org/maintenance_policy.html#severe-security-issues
[rails-5.0]: http://weblog.rubyonrails.org/2016/6/30/Rails-5-0-final/
[rails-5.1]: http://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final/