### PR TITLE
Remove add package version constraint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,16 +97,10 @@ $ cd path/to/frontend
 $ ember install ember-cli-rails-addon
 ```
 
-Be sure that the addon's [`MAJOR` and `MINOR` version][semver] matches the gem's
-`MAJOR` and `MINOR` versions.
-
-For instance, if you're using the `0.6.x` version of the gem, specify
-`~> 0.6.0` in your Ember app's `package.json`:
-
 ```json
 {
   "devDependencies": {
-    "ember-cli-rails-addon": "~> 0.6.0"
+    "ember-cli-rails-addon": "~> 0.8.0"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ $ cd path/to/frontend
 $ ember install ember-cli-rails-addon
 ```
 
+In your Ember app's `package.json`:
+
 ```json
 {
   "devDependencies": {


### PR DESCRIPTION
Remove documentation suggesting that ember-cli-rails MAJOR and MINOR versions be kept in sync with ember-cli-rails-addon. This documentation appears to be no longer valid since ember-cli-rails-addon has been at 0.8.0 for over a year.