### PR TITLE
Automatically redirect with a trailing slash when needed

### DIFF
--- a/lib/ember_cli/route_helpers.rb
+++ b/lib/ember_cli/route_helpers.rb
@@ -15,7 +15,16 @@ module ActionDispatch
         )
 
         scope constraints: ::EmberCli::EmberConstraint.new do
-          get("#{to}(*rest)", routing_options)
+          # Redirect if at the root and missing a trailing slash
+          get(to,
+            to: redirect(Proc.new do |_, request|
+              File.join(request.original_fullpath, "")
+            end),
+            constraints: Proc.new do |request|
+              request.original_fullpath &&
+                !request.original_fullpath.ends_with?("/")
+            end)
+          get(File.join(to, "(*rest)"), routing_options)
         end
 
         mount_ember_assets(app_name, to: to)

--- a/spec/features/user_views_ember_app_spec.rb
+++ b/spec/features/user_views_ember_app_spec.rb
@@ -35,6 +35,14 @@ feature "User views ember app", :js do
     end
   end
 
+  scenario "is redirected with trailing slash" do
+    expect(embedded_path).to eq("/asset-helpers")
+
+    visit embedded_path
+
+    expect(current_path).to eq("/asset-helpers/")
+  end
+
   def have_client_side_asset
     have_css %{img[src*="logo.png"]}
   end


### PR DESCRIPTION
For apps not mounted at `/`, apps need to write custom redirect login to add the trailing slash Ember requires - this simplified it by providing it as part of `mount_ember_app`.