### PR TITLE
Raise a DependencyError when Yarn is requested but not available

### DIFF
--- a/lib/ember_cli/path_set.rb
+++ b/lib/ember_cli/path_set.rb
@@ -92,7 +92,15 @@ module EmberCli
 
     def yarn
       if yarn?
-        @yarn ||= path_for_executable("yarn")
+        @yarn ||= path_for_executable("yarn").tap do |yarn_path|
+          unless yarn_path&.executable?
+            fail DependencyError.new <<-MSG.strip_heredoc
+                Yarn usage is requested but the executable is missing
+
+                Install it by following the instructions at https://yarnpkg.com/lang/en/docs/install/
+            MSG
+          end
+        end
       end
     end
 

--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -41,7 +41,7 @@ module EmberCli
         clean_ember_dependencies!
       end
 
-      if paths.yarn.present? && Pathname.new(paths.yarn).executable?
+      if paths.yarn
         run! "#{paths.yarn} install"
       else
         run! "#{paths.npm} prune && #{paths.npm} install"

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -212,13 +212,25 @@ describe EmberCli::PathSet do
     end
 
     context "when the executable isn't installed on the system" do
-      it "returns nil" do
-        stub_which(yarn: nil)
-        path_set = build_path_set
+      context "and yarn is requested" do
+        it "raises a DependencyError" do
+          stub_which(yarn: nil)
+          app = build_app(options: { yarn: true })
+          path_set = build_path_set(app: app)
 
-        yarn = path_set.yarn
+          expect { path_set.yarn }.to raise_error(EmberCli::DependencyError)
+        end
+      end
 
-        expect(yarn).to be_nil
+      context "and yarn is not requested" do
+        it "returns nil" do
+          stub_which(yarn: nil)
+          path_set = build_path_set
+
+          yarn = path_set.yarn
+
+          expect(yarn).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
I ended up hitting some cryptic errors because Yarn was no longer on `$PATH` and thus my dependencies weren't fixed. This change causes any attempted `yarn` commands to fail when `yarn` or `yarn_path` are provided instead of silently falling back to `npm`.