### PR TITLE
Configure Capybara to run `Webrick` in tests

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -16,4 +16,5 @@ Capybara.register_driver :headless_chrome do |app|
   )
 end
 
+Capybara.server = :webrick
 Capybara.javascript_driver = :headless_chrome


### PR DESCRIPTION
This commit resolves dependecy issues due to the absence of `puma` from
the project's Gemfiles:

```
Failure/Error: raise LoadError, "Capybara is unable to load `puma` for its server, please add `puma` to your project or specify a different server via something like `Capybara.server = :webrick`."

LoadError:
Capybara is unable to load `puma` for its server, please add `puma` to your project or specify a different server via something like `Capybara.server = :webrick`.
```

Instead of adding an additional dependency, configure Capybara to use
`webrick`, which is available as part of Ruby's standard library.