### PR TITLE
add install_command_line_arguments to pass through to install commands

### DIFF
--- a/lib/ember_cli/shell.rb
+++ b/lib/ember_cli/shell.rb
@@ -11,6 +11,7 @@ module EmberCli
         options: options,
       )
       @on_exit ||= at_exit { stop }
+      @options = options
     end
 
     def compile
@@ -42,9 +43,10 @@ module EmberCli
       end
 
       if paths.yarn
-        run! "#{paths.yarn} install"
+        run! "#{paths.yarn} install #{install_command_line_arguments}"
       else
-        run! "#{paths.npm} prune && #{paths.npm} install"
+        run! "#{paths.npm} prune && #{paths.npm} install " \
+          "#{install_command_line_arguments}"
       end
 
       if paths.bower_json.exist?
@@ -110,6 +112,10 @@ module EmberCli
 
     def detach
       Process.detach pid
+    end
+
+    def install_command_line_arguments
+      options.fetch(:install_command_line_arguments, "")
     end
   end
 end

--- a/spec/lib/ember_cli/app_spec.rb
+++ b/spec/lib/ember_cli/app_spec.rb
@@ -113,6 +113,19 @@ describe EmberCli::App do
     end
   end
 
+  describe "#install_dependencies" do
+    it "delegates to Shell" do
+      expected_install_result = "dummy-value"
+      allow_any_instance_of(EmberCli::Shell).
+        to receive(:install).
+        and_return(expected_install_result)
+      app = EmberCli::App.new("foo")
+
+      install_result = app.install_dependencies
+      expect(install_result).to eq expected_install_result
+    end
+  end
+
   def stub_paths(method_to_value)
     allow_any_instance_of(EmberCli::PathSet).
       to receive(method_to_value.keys.first).

--- a/spec/lib/ember_cli/shell_spec.rb
+++ b/spec/lib/ember_cli/shell_spec.rb
@@ -1,0 +1,50 @@
+require "ember_cli/shell"
+
+describe EmberCli::Shell do
+  describe "#install" do
+    it "runs the yarn install command" do
+      paths = build_paths
+      shell = build_shell(paths: paths)
+
+      expect_runner_to(:run, "/path/to/ember version").
+        and_return(double(success?: true))
+      expect_runner_to(:run!, "/path/to/yarn install ")
+
+      shell.install
+    end
+
+    context "when passing install_command_line_arguments" do
+      it "passes it to the command" do
+        paths = build_paths
+        shell = build_shell(
+          paths: paths,
+          options: { install_command_line_arguments: "--frozen-lockfile" },
+        )
+
+        expect_runner_to(:run, "/path/to/ember version").
+          and_return(double(success?: true))
+        expect_runner_to(:run!, "/path/to/yarn install --frozen-lockfile")
+
+        shell.install
+      end
+    end
+  end
+
+  def expect_runner_to(method_name, command_line)
+    expect_any_instance_of(EmberCli::Runner).
+      to receive(method_name).with(command_line)
+  end
+
+  def build_paths
+    double(
+      gemfile: double(exist?: false),
+      yarn: "/path/to/yarn",
+      bower_json: double(exist?: false),
+      ember: "/path/to/ember",
+    ).as_null_object
+  end
+
+  def build_shell(**options)
+    EmberCli::Shell.new(options)
+  end
+end


### PR DESCRIPTION
By default, yarn and npm will use updated versions of packages when possible.
This behavior may not be desirable in some cases, namely when using build systems
where you want to guarantee a specific version of your package is being used.

This change adds a new `install_command_line_arguments` option to the EmberCLI
initializer that can be used to customize the install command.