### PR TITLE
Recognize Building notice as not an error

### DIFF
--- a/lib/ember_cli/build_monitor.rb
+++ b/lib/ember_cli/build_monitor.rb
@@ -42,7 +42,8 @@ module EmberCli
     def build_errors
       error_lines.
         reject { |line| is_blank_or_backtrace?(line) }.
-        reject { |line| is_deprecation_warning?(line) }
+        reject { |line| is_deprecation_warning?(line) }.
+        reject { |line| is_building_notice?(line) }
     end
 
     def has_build_errors?
@@ -55,6 +56,10 @@ module EmberCli
 
     def is_deprecation_warning?(line)
       line =~ /^(\e[^\s]+)?DEPRECATION:/
+    end
+
+    def is_building_notice?(line)
+      line =~ /^(\e[^\s]+)?.\s(\e[^\s]+)?Building/
     end
 
     def error_lines

--- a/spec/lib/ember_cli/build_monitor_spec.rb
+++ b/spec/lib/ember_cli/build_monitor_spec.rb
@@ -86,6 +86,19 @@ describe EmberCli::BuildMonitor do
       end
     end
 
+    context "when the error file contains an ASCII colored Building notice" do
+      it "does not raise a BuildError" do
+        error_file = error_file_with_contents(
+          [
+            "- \e[32mBuilding\e[39m"
+          ])
+        paths = build_paths(error_file)
+        monitor = EmberCli::BuildMonitor.new(nil, paths)
+
+        expect(monitor.check!).to be true
+      end
+    end
+
     context "when the error file contains both errors & deprecation warnings" do
       it "raises a BuildError" do
         error_file = error_file_with_contents(


### PR DESCRIPTION
Newer versions of `ember-cli` seem to be putting a progress spinner with `- Building` on stderr, which `ember-cli-rails` doesn't recognize as not a `BuildError`. This adds a simple regex to detect--and ignore--this output.