### PR TITLE
Resolve setup issues causing test suite failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ cache:
 notifications:
   email: false
 rvm:
-  - 2.4.4
-  - 2.3.7
-  - 2.2.10
-  - jruby-9.1.16.0
+  - "2.6"
+  - "2.5"
+  - "2.4"
+  - "jruby-9.1.16.0"
 install: bin/setup_ci
 before_script:
   - export PATH="$HOME/.nvm/versions/node/v${NODE_JS_VERSION}/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,5 @@ gemfile:
 matrix:
   allow_failures:
     - gemfile: gemfiles/master.gemfile
+    - gemfile: gemfiles/4.2.gemfile
+    - rvm: jruby-9.1.16.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script: bin/rake
 env:
   global:
     - secure: RbWKxwfpzyQ5uv/jYH68/0J3Y9xe7rQbGULsWZT98FxZcVWLoOFlPPITmnmEK32CjQUww8iMz50FRLxFNmXg8prt1KzpzikVdIZLmYg1NFShI8+JOFhJzwCuk/LLybNUmydejR58FJvV9gS8NYqMh5leFkDM3OwLxhWdcE8hDDQ=
-    - NODE_JS_VERSION=7.10.0
+    - NODE_JS_VERSION=10.10.0
 gemfile:
   - gemfiles/4.2.gemfile
   - gemfiles/5.0.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,4 +1,5 @@
 appraise "4.2" do
+  gem "bundler", [">= 1.3.0", "< 2.0"]
   gem "rails", "~> 4.2.0"
 end
 

--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ This project supports:
 
 This project supports:
 
-* Ruby versions `>= 2.2.0`
+* Ruby versions `>= 2.4.0`
 * Rails versions `>=4.2.x`.
 
 To learn more about supported versions and upgrades, read the [upgrading guide].

--- a/bin/setup
+++ b/bin/setup
@@ -9,10 +9,6 @@ bundle check || bundle install
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe
 
-if ! command -v bower > /dev/null; then
-  npm install -g bower
-fi
-
 bin/setup_ember spec/dummy/my-app
 
 echo '-- Install Ember dependencies'

--- a/bin/setup_ci
+++ b/bin/setup_ci
@@ -20,6 +20,7 @@ node --version
 
 gem update --system
 
-gem install bundler --version "< 2.0"
+gem uninstall bundler --version ">= 2.0" || true
+gem install bundler --version ">= 1.3.0, < 2.0"
 
 source bin/setup

--- a/bin/setup_ci
+++ b/bin/setup_ci
@@ -2,15 +2,6 @@
 
 set -e
 
-install_chromedriver() {
-  wget -N http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip -P ~/
-  unzip ~/chromedriver_linux64.zip -d ~/
-  rm -v ~/chromedriver_linux64.zip
-  sudo mv -v -f ~/chromedriver /usr/local/share/
-  sudo chmod -v +x /usr/local/share/chromedriver
-  sudo ln -v -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
-}
-
 rm -rf ~/.nvm
 
 git clone https://github.com/creationix/nvm.git ~/.nvm
@@ -29,6 +20,6 @@ node --version
 
 gem update --system
 
-install_chromedriver
+gem install bundler --version "< 2.0"
 
 source bin/setup

--- a/bin/setup_ember
+++ b/bin/setup_ember
@@ -21,11 +21,6 @@ setup_ember() {
     cd $target &&
       npm install --save-dev ember-cli-rails-addon@rondale-sc/ember-cli-rails-addon
 
-    if [ -f "$target/bower.json" ]; then
-      echo '-- Install Bower dependencies'
-      cd $target && bower install
-    fi
-
     echo '-- Successfully setup Ember'
   fi
 }

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -21,9 +21,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "html_page", "~> 0.1.0"
 
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "bundler", "< 2.0"
   spec.add_development_dependency "generator_spec", "~> 0.9.0"
   spec.add_development_dependency "rspec-rails", "~> 3.6.0"
 
   spec.add_development_dependency "capybara-selenium"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.6.0"
+  spec.add_development_dependency "webdrivers", "~> 3.0"
 end

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "html_page", "~> 0.1.0"
 
   spec.add_development_dependency "appraisal"
-  spec.add_development_dependency "bundler", "< 2.0"
   spec.add_development_dependency "generator_spec", "~> 0.9.0"
   spec.add_development_dependency "rspec-rails", "~> 3.6.0"
 

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "high_voltage", "~> 3.0.0"
+gem "bundler", [">= 1.3.0", "< 2.0"]
 gem "rails", "~> 4.2.0"
 
 gemspec path: "../"

--- a/spec/fixtures/application.hbs
+++ b/spec/fixtures/application.hbs
@@ -1,4 +1,4 @@
 <p>Welcome to Ember</p>
-<img src="assets/logo.png">
+<img src="assets/logo.png" alt="Hampsters on a Treadmill">
 
 {{outlet}}

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,4 @@
+require "webdrivers"
 require "selenium/webdriver"
 
 Capybara.register_driver :chrome do |app|


### PR DESCRIPTION
In hopes of passing the test suite in CI, this commit:

* adds a dependency on `webdrivers` gem to manage the versions of
  ChromeDriver
* removes any setup-level dependency on `bower install` and `bower.json`
* Adds `alt` text to the test fixture template's `<img>` element