### PR TITLE
Drop support for End-of-Lifed Ruby versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.3", "2.4"]
+        ruby: ["2.5", "2.6"]
         rails: ["4.2", "5.0", "5.1", "5.2"]
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ master
 * Redirect Ember routes with paths that don't end in `/` to corresponding paths
   that end in `/`.
 * Don't route requests to `/rails/active_storage` through the mounted Ember application.
-
+* Only support for Ruby versions >= 2.5
 
 0.10.0
 ------

--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ This project supports:
 
 This project supports:
 
-* Ruby versions `>= 2.2.0`
+* Ruby versions `>= 2.5.0`
 * Rails versions `>=4.2.x`.
 
 To learn more about supported versions and upgrades, read the [upgrading guide].

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,6 @@
 # Ruby support
 
-According to [these release notes][latest-eol], Ruby versions prior to `2.1.x`
+According to [these release notes][latest-eol], Ruby versions prior to `2.5.x`
 has been end-of-lifed.
 
 Additionally, this codebase makes use of [(required) keyword arguments][kwargs].
@@ -14,15 +14,18 @@ which **requires** Ruby `2.2.2` or greater.
 From `ember-cli-rails@0.8.0` and on, we will no longer support versions of Ruby
 prior to `2.2.2`.
 
+From `ember-cli-rails@0.12.0` and on, we will no longer support versions of Ruby
+prior to `2.5.x`.
+
 To use `ember-cli-rails` with older versions of Ruby, try the `0.3.x` series.
 
 [kwargs]: https://robots.thoughtbot.com/ruby-2-keyword-arguments
-[latest-eol]: https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/
+[latest-eol]: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/
 
 # Rails support
 
 According to the [Rails Maintenance Policy][version-policy], Rails versions
-prior to `3.2.x` have been end-of-lifed. Additionally, the `4.0.x` series no
+prior to `5.2.x` have been end-of-lifed. Additionally, the `4.0.x` series no
 longer receives bug fixes of any sort.
 
 From `ember-cli-rails@0.4.0` and on, we will no longer support versions of Rails

--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license  = "MIT"
   spec.files    = Dir["README.md", "CHANGELOG.md", "LICENSE.txt", "{lib,app,config}/**/*"]
 
-  spec.required_ruby_version = ">= 2.2.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_dependency "ember-cli-rails-assets", "~> 0.6.2"
   spec.add_dependency "railties", ">= 4.2"


### PR DESCRIPTION
As of 20 June 2018, official support for [Ruby 2.2 has ended][2.2].

As of 31 March 2019, official support for [Ruby 2.3 has ended][2.3].

As of 5 April 2020, official support for [Ruby 2.4 has ended][2.4].

This commit configures the continuous integration test suite to execute
against `2.5`, `2.6`, and `2.7`.

Additionally, this commit amends the `README` to mention `2.5` as the
minimally supported version.

[2.2]: https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/
[2.3]: https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/
[2.4]: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/