### PR TITLE
Ignore `/rails/active_storage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ master
 * Switch from TravisCI to GitHub Actions for Continuous Integration
 * Redirect Ember routes with paths that don't end in `/` to corresponding paths
   that end in `/`.
+* Don't route requests to `/rails/active_storage` through the mounted Ember application.
+
 
 0.10.0
 ------

--- a/lib/ember_cli/ember_constraint.rb
+++ b/lib/ember_cli/ember_constraint.rb
@@ -1,13 +1,19 @@
 module EmberCli
   class EmberConstraint
     def matches?(request)
-      html_request?(request) && !rails_info_request?(request)
+      html_request?(request) &&
+        !rails_info_request?(request) &&
+        !rails_active_storage_request?(request)
     end
 
     private
 
     def rails_info_request?(request)
       request.fullpath.start_with?("/rails/info", "/rails/mailers")
+    end
+
+    def rails_active_storage_request?(request)
+      request.fullpath.start_with?("/rails/active_storage")
     end
 
     def html_request?(request)

--- a/spec/lib/ember_cli/ember_constraint_spec.rb
+++ b/spec/lib/ember_cli/ember_constraint_spec.rb
@@ -3,6 +3,15 @@ require "ember_cli/ember_constraint"
 describe EmberCli::EmberConstraint do
   describe "#matches?" do
     context %{when the format is "html"} do
+      context "when the request path is for a Rails active storage file" do
+        it "returns a falsey value" do
+          constraint = EmberCli::EmberConstraint.new
+          request = build_html_request("/rails/active_storage")
+
+          expect(constraint.matches?(request)).to be_falsey
+        end
+      end
+
       context "when the request path is for a Rails info page" do
         it "returns a falsey value" do
           constraint = EmberCli::EmberConstraint.new


### PR DESCRIPTION
Fix issue where active storage files without an extension would get clobbered. Fixes #581 