### PR TITLE
Drop support for End-of-Lifed Rails versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.5", "2.6"]
-        rails: ["4.2", "5.0", "5.1", "5.2"]
+        rails: ["5.2", "6.0"]
 
     env:
-      BUNDLER_VERSION: "1.17.0"
       RAILS_ENV: "test"
       RAILS_VERSION: "${{ matrix.rails }}"
 
@@ -36,8 +35,6 @@ jobs:
 
     - name: "Generate lockfile"
       run: |
-        gem uninstall bundler
-        gem install bundler -v 1.17.0
         bundle config path vendor/bundle
         bundle lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ master
   that end in `/`.
 * Don't route requests to `/rails/active_storage` through the mounted Ember application.
 * Only support for Ruby versions >= 2.5
+* Only support for Rails versions >= 5.2
 
 0.10.0
 ------

--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ This project supports:
 This project supports:
 
 * Ruby versions `>= 2.5.0`
-* Rails versions `>=4.2.x`.
+* Rails versions `>=5.2.x`.
 
 To learn more about supported versions and upgrades, read the [upgrading guide].
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,6 +31,9 @@ longer receives bug fixes of any sort.
 From `ember-cli-rails@0.4.0` and on, we will no longer support versions of Rails
 prior to `3.2.0`, nor will we support the `4.0.x` series of releases.
 
+From `ember-cli-rails@0.12.0` and on, we will no longer support versions of
+Rails prior to `5.2.0`.
+
 To use `ember-cli-rails` with older versions of Rails, try the `0.3.x` series.
 
 [version-policy]: http://guides.rubyonrails.org/maintenance_policy.html

--- a/bin/setup
+++ b/bin/setup
@@ -3,7 +3,7 @@
 set -e
 
 echo '-- Set up Ruby dependencies via Bundler'
-gem install bundler -v "${BUNDLER_VERSION-1.17.0}" --conservative
+gem install bundler --conservative
 bundle check || bundle install
 
 bin/rake webdrivers:chromedriver:update

--- a/spec/lib/ember_cli/ember_constraint_spec.rb
+++ b/spec/lib/ember_cli/ember_constraint_spec.rb
@@ -46,10 +46,10 @@ describe EmberCli::EmberConstraint do
   end
 
   def build_html_request(fullpath)
-    build_request(format: :html, fullpath: fullpath)
+    build_request(format: "text/html", fullpath: fullpath)
   end
 
   def build_json_request
-    build_request(format: :json)
+    build_request(format: "application/json")
   end
 end


### PR DESCRIPTION
At the time of pull request submission, [official Rails support for
versions `4.2`, `5.0`, and `5.1` have ended][maintenance_policy]

This commit configures the continuous integration test suite to execute
against `5.2` and `6.0`.

To support those versions in our continuous integration containers,
remove configuration code to limit the `bundler` version to `< 2.0`.

Additionally, this commit amends the `README` to mention `5.2` as the
minimally supported version.

[maintenance_policy]: https://guides.rubyonrails.org/maintenance_policy.html