### PR TITLE
Fix autoload deprecation in Rails 6

### DIFF
--- a/lib/ember_cli/engine.rb
+++ b/lib/ember_cli/engine.rb
@@ -1,10 +1,7 @@
 module EmberCli
   class Engine < Rails::Engine
     initializer "ember-cli-rails.setup" do
-      require "ember_cli/ember_controller"
       require "ember_cli/route_helpers"
-
-      ActionController::Base.helper EmberRailsHelper
     end
   end
 end


### PR DESCRIPTION
After upgrading an application to Rails 6, I noticed the following
deprecation warning:

> DEPRECATION WARNING: Initialization autoloaded the constants
ApplicationController

This appears to be due to the initializer requiring `EmberController`,
which shouldn't be necessary since that class is already in
`app/controllers`, which is autoloaded. Similarly `EmberRailsHelper` is
autoloaded and shouldn't need to be referenced here.