### PR TITLE
Ignore query params in trailing slash constraint

### DIFF
--- a/lib/ember_cli/trailing_slash_constraint.rb
+++ b/lib/ember_cli/trailing_slash_constraint.rb
@@ -1,7 +1,7 @@
 module EmberCli
   class TrailingSlashConstraint
     def matches?(request)
-      !request.original_fullpath.to_s.ends_with?("/")
+      !request.original_fullpath.to_s.split('?')[0].ends_with?("/")
     end
   end
 end

--- a/lib/ember_cli/trailing_slash_constraint.rb
+++ b/lib/ember_cli/trailing_slash_constraint.rb
@@ -1,7 +1,7 @@
 module EmberCli
   class TrailingSlashConstraint
     def matches?(request)
-      !request.original_fullpath.to_s.split('?')[0].ends_with?("/")
+      !request.original_fullpath.to_s.split("?")[0].ends_with?("/")
     end
   end
 end


### PR DESCRIPTION
If someone refreshes a page with query params, a slash is added on the end, breaking the last parameter. This strips anything after a question mark in the url before checking for a trailing slash. 

This appears to only come into play with a root url?