### PR TITLE
Support Ruby 3.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6"]
+        ruby: ["2.5", "2.6", "2.7", "3.0"]
         rails: ["5.2", "6.0"]
+        exclude:
+          - ruby: "3.0"
+            rails: "5.2"
 
     env:
       RAILS_ENV: "test"

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,6 @@ end
 
 gem "rails", rails_constraint
 gem "high_voltage", "~> 3.0.0"
+gem "rexml" # For selenium-webdriver on Ruby 3.0.0. This is required until selenium-webdriver 4 is released. https://github.com/SeleniumHQ/selenium/pull/9007
 gem "webdrivers", "~> 4.0"
+gem "webrick"

--- a/lib/ember_cli/configuration.rb
+++ b/lib/ember_cli/configuration.rb
@@ -8,7 +8,7 @@ module EmberCli
     attr_accessor :watcher
 
     def app(name, **options)
-      app = App.new(name, options)
+      app = App.new(name, **options)
       apps.store(name, app)
     end
 

--- a/spec/generators/ember/heroku/heroku_generator_spec.rb
+++ b/spec/generators/ember/heroku/heroku_generator_spec.rb
@@ -106,8 +106,8 @@ describe EmberCli::HerokuGenerator, type: :generator do
     end
   end
 
-  def configure_application(options = {})
-    EmberCli.configure { |c| c.app("my-app", options) }
+  def configure_application(**options)
+    EmberCli.configure { |c| c.app("my-app", **options) }
   end
 
   def setup_destination

--- a/spec/lib/ember_cli/command_spec.rb
+++ b/spec/lib/ember_cli/command_spec.rb
@@ -111,6 +111,6 @@ describe EmberCli::Command do
   end
 
   def build_command(**options)
-    EmberCli::Command.new(options)
+    EmberCli::Command.new(**options)
   end
 end

--- a/spec/lib/ember_cli/path_set_spec.rb
+++ b/spec/lib/ember_cli/path_set_spec.rb
@@ -364,7 +364,7 @@ describe EmberCli::PathSet do
 
   def build_path_set(**options)
     EmberCli::PathSet.new(
-      options.reverse_merge(
+      **options.reverse_merge(
         app: build_app,
         rails_root: rails_root,
         ember_cli_root: ember_cli_root,


### PR DESCRIPTION
This PR fixes ember-cli-rails to work on Ruby 3.0.0.

This is a release note
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

Ruby 3.0.0 has some breaking changes like the following:
- Keyword arguments are separated from other arguments
- Some standard gems are not bundled

This PR follows up them to work with current support Ruby versions including 3.0.0.

----

Without this change, booting ember-cli-rails fails by the following error.
```
/bundle/ruby/3.0.0/gems/ember-cli-rails-0.11.0/lib/ember_cli/app.rb:11:in `initialize': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from /bundle/ruby/3.0.0/gems/ember-cli-rails-0.11.0/lib/ember_cli/configuration.rb:11:in `new'
	from /bundle/ruby/3.0.0/gems/ember-cli-rails-0.11.0/lib/ember_cli/configuration.rb:11:in `app'
```