### PR TITLE
Redirecting with trailing slash with query parameters

### DIFF
--- a/bin/setup_ember
+++ b/bin/setup_ember
@@ -6,7 +6,7 @@ setup_ember() {
   local target="${1-spec/dummy/my-app}"
 
   if ! [ -d $target ]; then
-    git clone -b stable https://github.com/ember-cli/ember-new-output.git $target
+    git clone -b 'v4.0.0' https://github.com/ember-cli/ember-new-output.git $target
 
     echo '-- Make router catchall routes'
     sed -i -e 's/auto/hash/' $target/config/environment.js

--- a/lib/ember_cli/route_helpers.rb
+++ b/lib/ember_cli/route_helpers.rb
@@ -19,7 +19,7 @@ module ActionDispatch
           redirect_if_missing_trailing_slash = {
             constraints: EmberCli::TrailingSlashConstraint.new,
             to: redirect(-> (_, request) {
-              File.join(request.original_fullpath, "")
+              File.join(request.path, "/?#{request.query_parameters.to_query}")
             }),
           }
 

--- a/lib/ember_cli/trailing_slash_constraint.rb
+++ b/lib/ember_cli/trailing_slash_constraint.rb
@@ -1,7 +1,7 @@
 module EmberCli
   class TrailingSlashConstraint
     def matches?(request)
-      !request.original_fullpath.to_s.ends_with?("/")
+      !request.original_fullpath.to_s.split('?').first.end_with?("/")
     end
   end
 end

--- a/lib/ember_cli/trailing_slash_constraint.rb
+++ b/lib/ember_cli/trailing_slash_constraint.rb
@@ -1,7 +1,7 @@
 module EmberCli
   class TrailingSlashConstraint
     def matches?(request)
-      !request.original_fullpath.to_s.split('?').first.end_with?("/")
+      !request.original_fullpath.to_s.split("?").first.end_with?("/")
     end
   end
 end

--- a/spec/features/user_views_ember_app_spec.rb
+++ b/spec/features/user_views_ember_app_spec.rb
@@ -35,7 +35,7 @@ feature "User views ember app", :js do
     end
   end
 
-  scenario "is redirected with trailing slash", js: false, focus: true do
+  scenario "is redirected with trailing slash", js: false do
     expect(embedded_path).to eq("/asset-helpers")
 
     visit embedded_path
@@ -43,10 +43,18 @@ feature "User views ember app", :js do
     expect(current_path).to eq("/asset-helpers/")
   end
 
-  scenario "is redirected without trailing slash when it has query params", js: false, focus: true do
-    expect(embedded_path(query: 'foo')).to eq("/asset-helpers?query=foo")
+  scenario "is redirected with trailing slash with query params", js: false do
+    expect(embedded_path(query: "foo")).to eq("/asset-helpers?query=foo")
 
-    visit embedded_path(query: 'foo')
+    visit embedded_path(query: "foo")
+
+    expect(page).to have_current_path("/asset-helpers/?query=foo")
+  end
+
+  scenario "is not redirected with trailing slash with params", js: false do
+    expect(embedded_path(query: "foo")).to eq("/asset-helpers?query=foo")
+
+    visit "/asset-helpers/?query=foo"
 
     expect(page).to have_current_path("/asset-helpers/?query=foo")
   end

--- a/spec/features/user_views_ember_app_spec.rb
+++ b/spec/features/user_views_ember_app_spec.rb
@@ -35,12 +35,20 @@ feature "User views ember app", :js do
     end
   end
 
-  scenario "is redirected with trailing slash", js: false do
+  scenario "is redirected with trailing slash", js: false, focus: true do
     expect(embedded_path).to eq("/asset-helpers")
 
     visit embedded_path
 
     expect(current_path).to eq("/asset-helpers/")
+  end
+
+  scenario "is redirected without trailing slash when it has query params", js: false, focus: true do
+    expect(embedded_path(query: 'foo')).to eq("/asset-helpers?query=foo")
+
+    visit embedded_path(query: 'foo')
+
+    expect(page).to have_current_path("/asset-helpers/?query=foo")
   end
 
   def have_client_side_asset


### PR DESCRIPTION
Fixes the bug when redirecting with a trailing slash with query parameters resulting in an invalid URL
eg: `https://app.com?query=foo` would redirect to `https://app.com?query=foo/`, which is invalid

This PR fixes this issue adding the trailing slash before the query parameters
eg: `https://app.com?query=foo` would be redirected to `https://app.com/?query=foo`
