### PR TITLE
Allow ember-cli-rails-assets < 1.0

### DIFF
--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "ember-cli-rails-assets", "~> 0.6.2"
+  spec.add_dependency "ember-cli-rails-assets", ">= 0.6.2", "< 1.0"
   spec.add_dependency "railties", ">= 4.2"
   spec.add_dependency "terrapin", "~> 0.6.0"
   spec.add_dependency "html_page", "~> 0.1.0"


### PR DESCRIPTION
It will be release in https://github.com/seanpdoyle/ember-cli-rails-assets/pull/18.