### PR TITLE
Update webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ gem "rails", rails_constraint
 gem "ember-cli-rails-assets", github: "seanpdoyle/ember-cli-rails-assets" if rails_version == "main" || Gem::Version.new(rails_version) >= Gem::Version.new("7.0")
 gem "high_voltage", "~> 3.0.0"
 gem "rexml" # For selenium-webdriver on Ruby 3.0.0. This is required until selenium-webdriver 4 is released. https://github.com/SeleniumHQ/selenium/pull/9007
-gem "webdrivers", "~> 4.0"
+gem "webdrivers", "~> 5.0"
 gem "webrick"


### PR DESCRIPTION
To support current platforms.

On my laptop, M1 macOC shows the following error with webdrivers ~> 4.0:
```
Webdrivers::NetworkError: Net::HTTPClientException: 404 "Not Found" with https://chromedriver.storage.googleapis.com/110.0.5481.77/chromedriver_mac64_m1.zip
```