### PR TITLE
Disallow rack 3 to be compatible with capybara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ rails_version = ENV.fetch("RAILS_VERSION", "6.0")
 
 if rails_version == "main"
   rails_constraint = { github: "rails/rails" }
+  gem "rack", "< 3" # To compatible with capybara. https://github.com/teamcapybara/capybara/issues/2640
 else
   rails_constraint = "~> #{rails_version}.0"
 end


### PR DESCRIPTION
Rails main allow rack 3 in https://github.com/rails/rails/pull/46594. However, capybara doesn't support rack 3 yet. https://github.com/teamcapybara/capybara/issues/2640

To test only for rails gem, lock rack version in 2.x.