### PR TITLE
Drop explicit dependency to rexml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,5 @@ end
 gem "rails", rails_constraint
 gem "ember-cli-rails-assets", github: "seanpdoyle/ember-cli-rails-assets" if rails_version == "main" || Gem::Version.new(rails_version) >= Gem::Version.new("7.0")
 gem "high_voltage", "~> 3.0.0"
-gem "rexml" # For selenium-webdriver on Ruby 3.0.0. This is required until selenium-webdriver 4 is released. https://github.com/SeleniumHQ/selenium/pull/9007
 gem "webdrivers", "~> 5.0"
 gem "webrick"


### PR DESCRIPTION
Now, the latest version of selenium-webdriver is 4.8.0.
- https://rubygems.org/gems/selenium-webdriver/versions/4.8.0

It has rexml as its own dependency.