### PR TITLE
Remove note for PhantomJS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,7 @@ issue trackers, chatrooms, and mailing lists.
 
 ## Setup
 
-After cloning the repository, install [PhantomJS](http://phantomjs.org/)
-if you don't already have it, and execute the setup script:
+After cloning the repository, execute the setup script:
 
     $ bin/setup
 


### PR DESCRIPTION
Since 4b2f666b366ca115a4ca7b6613325a882159dac4, we use chromedriver instead of PhantomJS.