### PR TITLE
Support Rack 3

### DIFF
--- a/ember-cli-rails.gemspec
+++ b/ember-cli-rails.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ember-cli-rails-assets", ">= 0.6.2", "< 1.0"
   spec.add_dependency "railties", ">= 4.2"
+  spec.add_dependency "rack", ">= 2.1", "< 4.0"
   spec.add_dependency "terrapin", "~> 0.6.0"
   spec.add_dependency "html_page", "~> 0.1.0"
 

--- a/lib/ember_cli/deploy/file.rb
+++ b/lib/ember_cli/deploy/file.rb
@@ -13,7 +13,7 @@ module EmberCli
       end
 
       def to_rack
-        Rack::File.new(app.dist_path.to_s, rack_headers)
+        Rack::Files.new(app.dist_path.to_s, rack_headers)
       end
 
       def index_html

--- a/spec/lib/ember_cli/deploy/file_spec.rb
+++ b/spec/lib/ember_cli/deploy/file_spec.rb
@@ -33,7 +33,7 @@ describe EmberCli::Deploy::File do
   end
 
   describe "#to_rack" do
-    it "creates a Rack::File instance" do
+    it "creates a Rack::Files instance" do
       deploy = EmberCli::Deploy::File.new(build_app)
 
       rack_app = deploy.to_rack


### PR DESCRIPTION
This PR resolves deprecation since rack 3.
```
/home/runner/work/ember-cli-rails/ember-cli-rails/vendor/bundle/ruby/3.0.0/gems/rack-3.0.9/lib/rack/file.rb:5: warning: Rack::File is deprecated and will be removed in Rack 3.1
```

This change works file with the following RP like [this](https://github.com/tricknotes/ember-cli-rails/actions/runs/7742204968/job/21110797571) ([commit](https://github.com/tricknotes/ember-cli-rails/commit/b223a06c355867d07f3dab1e30a8e0ca5af492c9)).
- https://github.com/thoughtbot/ember-cli-rails/pull/606