### PR TITLE
Drop rack version restriction in test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ rails_version = ENV.fetch("RAILS_VERSION", "6.0")
 
 if rails_version == "main"
   rails_constraint = { github: "rails/rails" }
-  gem "rack", "< 3" # To compatible with capybara. https://github.com/teamcapybara/capybara/issues/2640
 else
   rails_constraint = "~> #{rails_version}.0"
 end


### PR DESCRIPTION
This landed in https://github.com/thoughtbot/ember-cli-rails/pull/601 due to capybara incompatibility with rack 3.

However, this issue has been solved in https://github.com/teamcapybara/capybara/issues/2640.