### PR TITLE
Remove ad-hoc dependency from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ else
 end
 
 gem "rails", rails_constraint
-gem "ember-cli-rails-assets", github: "seanpdoyle/ember-cli-rails-assets" if rails_version == "main" || Gem::Version.new(rails_version) >= Gem::Version.new("7.0")
 gem "high_voltage", "~> 3.0.0"
 gem "webdrivers", "~> 5.0"
 gem "webrick"


### PR DESCRIPTION
This code was introduced in https://github.com/thoughtbot/ember-cli-rails/pull/598/commits/367e42831771f9e0fbcb6430016b3bc9c490b27a

However, ember-cli-rails-assets 0.7.0 solved Rails ~>7.0 issues.